### PR TITLE
Enable Janitor processes by default

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,7 +25,7 @@ The second and third arguments are both optional and represent cache and server 
 |        ode       |  `true` or `false` |  Whether or not to enable on-demand expirations when reading back keys. |
 |   record_stats   |  `true` or `false` |            Whether to track statistics for this cache or not.           |
 |   transactions   |  `true` or `false` |             Whether to turn on transactions at cache start.             |
-|   ttl_interval   |     milliseconds   |          The frequency the Janitor process runs at (see below).         |
+|   ttl_interval   |     milliseconds   |                The frequency the Janitor process runs at.               |
 
 ## Main Interface
 

--- a/docs/ttl-implementation.md
+++ b/docs/ttl-implementation.md
@@ -8,11 +8,10 @@ The Janitor is a background process which will purge the internal tables every s
 
 As it stands the Janitor is pretty well optimized as most expense is handed over to the ETS layer; it can currently check and purge 500,000 expired keys in around a second (where the removal takes the most time, the check is very fast). Keep in mind that the frequency of the Janitor execution affects the memory usage held by expired keys; a typical use case is probably running the Janitor every few seconds, which is pretty much the default. In a production application I know of using Cachex, Janitors have been running every 3 seconds for the last year and there has never been any noticeable slowdown.
 
-There are several rules to take note of when setting up the Janitor interval, as it's not enabled by default (most Cachex features are opt-in):
+As of Cachex v3, the Janitor configuration is easier to understand, and will be enabled by default to avoid catching users off guard:
 
-- If you have `default_ttl` set in the cache options and you have not set `ttl_interval` the Janitor will default to running every N seconds. This is to avoid people forgetting to set it or simply being unaware that it's not running by default.
-- If you set `ttl_interval` to `-1` it is disabled entirely - even if you have a `default_ttl` set. This means you will be solely reliant on the on-demand expiration policy.
-- If you set `ttl_interval` to `true` it behaves the same way as if you had set a `default_ttl`; it will set the Janitor to run every N seconds.
+- By default, the Janitor will run every 3 seconds.
+- If you set `ttl_interval` to `-1` it is disabled entirely. This means you will be solely reliant on the on-demand expiration policy.
 - If you set `ttl_interval` to any numeric value above `0` it will run on this schedule (this value is in milliseconds).
 
 Please note that this is rolling interval that is set to trigger after completion of a run, meaning that if you schedule a Janitor every 5s it will be 5s after a successful run rather than 5s after the last trigger fired to start a run.

--- a/lib/cachex/options.ex
+++ b/lib/cachex/options.ex
@@ -38,19 +38,19 @@ defmodule Cachex.Options do
         { default_ttl, ttl_interval, janitor } = ttl_result
 
         state = %Cachex.State{
-          "cache": cache,
-          "commands": cmd_result,
-          "default_ttl": default_ttl,
-          "ets_opts": ets_result,
-          "fallback": fb_result,
-          "janitor": janitor,
-          "limit": limit_result,
-          "manager": manager,
-          "ode": ode_result,
-          "pre_hooks": pre_hooks,
-          "post_hooks": post_hooks,
-          "transactions": transactional,
-          "ttl_interval": ttl_interval
+          cache: cache,
+          commands: cmd_result,
+          default_ttl: default_ttl,
+          ets_opts: ets_result,
+          fallback: fb_result,
+          janitor: janitor,
+          limit: limit_result,
+          manager: manager,
+          ode: ode_result,
+          pre_hooks: pre_hooks,
+          post_hooks: post_hooks,
+          transactions: transactional,
+          ttl_interval: ttl_interval
         }
 
         { :ok, state }
@@ -138,6 +138,8 @@ defmodule Cachex.Options do
     |> Util.wrap(:ok)
   end
 
+  # Parses out whether the user wishes to disable on-demand expirations or not. It
+  # can be disabled by setting the `:ode` flag to `false`. Defaults to `true`.
   defp setup_ode(_cache, options) do
     options
     |> Util.get_opt(:ode, &is_boolean/1, true)
@@ -163,17 +165,15 @@ defmodule Cachex.Options do
       is_integer(val) and val > 0
     end)
 
-    ttl_interval = Util.get_opt(options, :ttl_interval, fn(val) ->
-      is_integer(val) and val >= -1
-    end)
+    ttl_interval = Util.get_opt(options, :ttl_interval, &is_integer/1)
 
-    opts = case ttl_interval do
-      nil when default_ttl != nil ->
-        { default_ttl, :timer.seconds(3), janitor_name }
-      val when val > -1 ->
-        { default_ttl, val, janitor_name }
-      _na ->
+    opts = cond do
+      ttl_interval == -1 ->
         { default_ttl, nil, nil }
+      is_nil(ttl_interval) ->
+        { default_ttl, :timer.seconds(3), janitor_name }
+      true ->
+        { default_ttl, ttl_interval, janitor_name }
     end
 
     { :ok, opts }

--- a/test/cachex/actions/inspect_test.exs
+++ b/test/cachex/actions/inspect_test.exs
@@ -45,8 +45,8 @@ defmodule Cachex.Actions.InspectTest do
   # error is returned if there is no Janitor process started for the cache.
   test "inspecting janitor metadata" do
     # create a cache with no janitor and one with
-    cache1 = Helper.create_cache()
-    cache2 = Helper.create_cache([ ttl_interval: 1 ])
+    cache1 = Helper.create_cache([ ttl_interval: -1 ])
+    cache2 = Helper.create_cache([ ttl_interval:  1 ])
 
     # let the janitor run
     :timer.sleep(2)

--- a/test/cachex/options_test.exs
+++ b/test/cachex/options_test.exs
@@ -327,17 +327,17 @@ defmodule Cachex.OptionsTest do
     assert(state4.default_ttl == nil)
     assert(state4.ttl_interval == 500)
 
-    # the fifth state should have both disabled
+    # the fifth state should have ttl_interval enabled
     assert(state5.default_ttl == nil)
-    assert(state5.ttl_interval == nil)
+    assert(state5.ttl_interval == 3000)
 
-    # the sixth state should have both disabled
+    # the sixth state should have ttl_interval enabled
     assert(state6.default_ttl == nil)
-    assert(state6.ttl_interval == nil)
+    assert(state6.ttl_interval == 3000)
 
-    # the seventh state should have both disabled
+    # the seventh state should have ttl_interval enabled
     assert(state7.default_ttl == nil)
-    assert(state7.ttl_interval == nil)
+    assert(state7.ttl_interval == 3000)
 
     # the eight state should have both disabled
     assert(state8.default_ttl == nil)


### PR DESCRIPTION
This fixes #108.

This PR changes the Janitor to run by default, as it was previously misleading to have a Janitor not running whilst supporting arbitrary TTLs being set. It can be disabled by setting the `:ttl_interval` option to `-1` (the same as before).