### PR TITLE
Remove requestCount from the stats plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: elixir
 elixir:
+  - 1.5.2
   - 1.4.5
   - 1.3.4
   - 1.2.6
 otp_release:
-  - 20.0
+  - 20.1
   - 19.3
   - 18.3
-env:
-  - MIX_ENV=test
+branches:
+  only:
+  - master
 matrix:
   exclude:
   - elixir: 1.3.4
@@ -22,6 +24,5 @@ script:
   - mix credo --all --format=oneline
   - mix coveralls.travis --trace
   - mix bench
-branches:
-  only:
-    - master
+env:
+  - MIX_ENV=test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: elixir
 elixir:
   - 1.5.2
   - 1.4.5
-  - 1.3.4
-  - 1.2.6
 otp_release:
   - 20.1
   - 19.3
@@ -11,12 +9,6 @@ otp_release:
 branches:
   only:
   - master
-matrix:
-  exclude:
-  - elixir: 1.3.4
-    otp_release: 20.1
-  - elixir: 1.2.6
-    otp_release: 20.1
 before_install:
   - rm mix.lock
   - mix local.rebar --force

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ branches:
 matrix:
   exclude:
   - elixir: 1.3.4
-    otp_release: 20.0
+    otp_release: 20.1
   - elixir: 1.2.6
-    otp_release: 20.0
+    otp_release: 20.1
 before_install:
   - rm mix.lock
   - mix local.rebar --force

--- a/lib/cachex/actions/stats.ex
+++ b/lib/cachex/actions/stats.ex
@@ -88,22 +88,19 @@ defmodule Cachex.Actions.Stats do
   # and miss rates, as well as counts of hits and misses. This has to be defined
   # as separate functions in order to handle potential division by 0. All rates
   # will always be floats to ensure consistency (even when they are whole numbers).
-  defp generate_rates(reqs, 0, misses), do: %{
-    requestCount: reqs,
+  defp generate_rates(_reqs, 0, misses), do: %{
     hitCount: 0,
     hitRate: 0.0,
     missCount: misses,
     missRate: 100.0
   }
-  defp generate_rates(reqs, hits, 0), do: %{
-    requestCount: reqs,
+  defp generate_rates(_reqs, hits, 0), do: %{
     hitCount: hits,
     hitRate: 100.0,
     missCount: 0,
     missRate: 0.0
   }
   defp generate_rates(reqs, hits, misses), do: %{
-    requestCount: reqs,
     hitCount: hits,
     hitRate: (hits / reqs) * 100,
     missCount: misses,

--- a/lib/cachex/stats.ex
+++ b/lib/cachex/stats.ex
@@ -138,8 +138,11 @@ defmodule Cachex.Stats do
 
   # Converts the result of a request into the type of count it should increment
   # in the global statistics namespace.
-  defp normalize_status(:ok), do: [ :hitCount ]
-  defp normalize_status(:missing), do: [ :missCount ]
-  defp normalize_status(:loaded), do: [ :missCount, :loadCount ]
+  defp normalize_status(:ok),
+    do: [ :hitCount ]
+  defp normalize_status(:missing),
+    do: [ :missCount ]
+  defp normalize_status(:loaded),
+    do: [ :missCount, :loadCount ]
 
 end

--- a/test/cachex/actions/stats_test.exs
+++ b/test/cachex/actions/stats_test.exs
@@ -33,7 +33,6 @@ defmodule Cachex.Actions.StatsTest do
     assert(stats1.hitRate == 100)
     assert(stats1.missRate == 0)
     assert(stats1.opCount == 2)
-    assert(stats1.requestCount == 1)
     assert(stats1.setCount == 1)
 
     # verify the second returns the global entries under a global key
@@ -134,8 +133,7 @@ defmodule Cachex.Actions.StatsTest do
       hitRate: 0.0,
       missCount: 1,
       missRate: 100.0,
-      opCount: 1,
-      requestCount: 1
+      opCount: 1
     })
 
     # verify a 100% hit rate for cache2
@@ -145,7 +143,6 @@ defmodule Cachex.Actions.StatsTest do
       missCount: 0,
       missRate: 0.0,
       opCount: 2,
-      requestCount: 1,
       setCount: 1
     })
 
@@ -156,7 +153,6 @@ defmodule Cachex.Actions.StatsTest do
       missCount: 1,
       missRate: 50.0,
       opCount: 3,
-      requestCount: 2,
       setCount: 1
     })
 
@@ -168,7 +164,6 @@ defmodule Cachex.Actions.StatsTest do
       missCount: 1,
       missRate: 100.0,
       opCount: 2,
-      requestCount: 1,
       setCount: 1
     })
   end


### PR DESCRIPTION
This fixes #117 by removing the `requestCount` from the stats hook. It can be filled in easily by the consumer if needed, but is just wasted space for the time being. `opCount` serves a much more generic purpose and makes much more sense.