### PR TITLE
Replace the internal defwrap macro with @unsafe

### DIFF
--- a/lib/cachex/lock_manager.ex
+++ b/lib/cachex/lock_manager.ex
@@ -68,5 +68,4 @@ defmodule Cachex.LockManager do
   defp safe_exec(fun, to_exec) do
     transaction?() && fun.() || to_exec.()
   end
-
 end

--- a/lib/cachex/macros.ex
+++ b/lib/cachex/macros.ex
@@ -5,15 +5,6 @@ defmodule Cachex.Macros do
   # for specific uses (to avoid bloating requires and imports). I'm pretty new
   # to Macros so if anything in here (or in submodules) can be done more efficiently,
   # feel free to suggest.
-  #
-  # The main offering here is the `defwrap` macro which provides shorthand wrappers
-  # to a Cachex action, by generating an "unsafe" version of each function. Unsafe
-  # functions will throw any errors, and return raw results.
-
-  # add various aliases
-  alias Cachex.Errors
-  alias Cachex.ExecutionError
-  alias Cachex.Util
 
   @doc """
   Trim all defaults from a set of arguments.
@@ -34,33 +25,4 @@ defmodule Cachex.Macros do
     do: { name, arguments, condition }
   def unpack_head({ name, _, arguments }),
     do: { name, arguments, nil }
-
-  @doc """
-  Defines both a safe and unsafe version of an interface function, the unsafe
-  version simply unwrapping the results of the safe version.
-  """
-  defmacro defwrap(head, do: body) do
-    { name, arguments, _condition } = unpack_head(head)
-
-    explicit_name  = Util.atom_append(name, "!")
-    sanitized_args = trim_defaults(arguments)
-
-    quote do
-      def unquote(head) do
-        unquote(body)
-      end
-
-      @doc false
-      def unquote(explicit_name)(unquote_splicing(arguments)) do
-        case unquote(name)(unquote_splicing(sanitized_args)) do
-          { :error, value } when is_atom(value) ->
-            raise ExecutionError, message: Errors.long_form(value)
-          { :error, value } when is_binary(value) ->
-            raise ExecutionError, message: value
-          { _state, value } ->
-            value
-        end
-      end
-    end
-  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Cachex.Mixfile do
   use Mix.Project
 
   @url_docs "http://hexdocs.pm/cachex"
-  @url_github "https://github.com/zackehh/cachex"
+  @url_github "https://github.com/whitfin/cachex"
 
   def project do
     [
@@ -76,6 +76,7 @@ defmodule Cachex.Mixfile do
     [
       # Production dependencies
       { :eternal, "~> 1.1" },
+      { :unsafe,  "~> 1.0" },
       # Local dependencies
       { :benchfella,  "~> 0.3",  optional: true, only: [ :dev, :test ] },
       { :bmark,       "~> 1.0",  optional: true, only: [ :dev, :test ] },

--- a/mix.lock
+++ b/mix.lock
@@ -17,4 +17,5 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [], [], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"}}
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
+  "unsafe": {:hex, :unsafe, "1.0.0", "7c21742cd05380c7875546b023481d3a26f52df8e5dfedcb9f958f322baae305", [], [], "hexpm"}}

--- a/test/cachex/macros_test.exs
+++ b/test/cachex/macros_test.exs
@@ -1,45 +1,6 @@
 defmodule Cachex.MacrosTest do
   use CachexCase
 
-  # This tests ensures that we provide delegate functions for Cachex functions
-  # which unwrap errors automatically. We do this by creating a `defwrap` function
-  # in this module and calling it with a combination of arguments which cause both
-  # valid results and errors. We also make sure that we test default arguments
-  # and guard clauses against this macro to ensure that we don't hit errors there.
-  test "generating unsafe function delegates" do
-    # execute safe tests
-    result1 = my_func("key")
-    result2 = my_func("key", "error")
-    result3 = my_func!("key")
-
-    # first two should be wrapped
-    assert(result1 == { :ok, "key" })
-    assert(result2 == { :error, "error" })
-
-    # the third should be unwrapped
-    assert(result3 == "key")
-
-    # ensure unsafe errors are thrown
-    assert_raise(Cachex.ExecutionError, "this is my error", fn ->
-      my_func!("key", "this is my error")
-    end)
-
-    # ensure unsafe errors are normalized
-    assert_raise(Cachex.ExecutionError, Cachex.Errors.long_form(:no_cache), fn ->
-      my_func!("key", :no_cache)
-    end)
-
-    # ensure that guard clauses also work
-    result4 = my_func_with_guard("key")
-    result5 = my_func_with_guard!("key")
-
-    # first should be wrapped
-    assert(result4 == { :ok, "key" })
-
-    # second should be unwrapped
-    assert(result5 == "key")
-  end
-
   # This test ensures that we can retrieve a three element Tuple from a function
   # head AST, regardless of whether the function head has guard clauses or not.
   test "retrieving a functions name and arguments" do
@@ -134,19 +95,4 @@ defmodule Cachex.MacrosTest do
       { :bonuses, [ line: 234 ], nil }
     ])
   end
-
-  # This function tests the defwrap macro whilst using default arguments.
-  defwrap my_func(key, err \\ false) do
-    if err do
-      { :error, err }
-    else
-      { :ok, key }
-    end
-  end
-
-  # This function tests the defwrap macro whilst using guard clases.
-  defwrap my_func_with_guard(key) when is_binary(key) do
-    { :ok, key }
-  end
-
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -31,5 +31,4 @@ defmodule TestHelper do
       end
     end)
   end
-
 end


### PR DESCRIPTION
This fixes #132.

This will replace `defwrap` with the `@unsafe` library in order to make it easier to define unsafe definitions. It also removes the internal mess for the `defwrap` definition and makes it easier to define multiple function definitions in the main API.