### PR TITLE
Enable default fetch functions on a cache

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -11,7 +11,6 @@
     "^\\s+use\\s+"
   ],
   "custom_stop_words": [
-    "defwrap.+",
     "{ :ok, .+_result } <-"
   ],
   "coverage_options": {

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -60,37 +60,37 @@ defmodule Cachex do
 
   # generate unsafe definitions
   @unsafe [
-    clear:          [ 1, 2 ],
-    count:          [ 1, 2 ],
-    decr:           [ 2, 3 ],
-    del:            [ 2, 3 ],
-    dump:           [ 2, 3 ],
-    empty?:         [ 1, 2 ],
-    execute:        [ 2, 3 ],
-    exists?:        [ 2, 3 ],
-    expire:         [ 3, 4 ],
-    expire_at:      [ 3, 4 ],
-    fetch:          [ 3, 4 ],
-    get:            [ 2, 3 ],
-    get_and_update: [ 3, 4 ],
-    incr:           [ 2, 3 ],
-    inspect:           [ 2 ],
-    invoke:         [ 3, 4 ],
-    keys:           [ 1, 2 ],
-    load:           [ 2, 3 ],
-    persist:        [ 2, 3 ],
-    purge:          [ 1, 2 ],
-    refresh:        [ 2, 3 ],
-    reset:          [ 1, 2 ],
-    set:            [ 3, 4 ],
-    size:           [ 1, 2 ],
-    stats:          [ 1, 2 ],
-    stream:         [ 1, 2 ],
-    take:           [ 2, 3 ],
-    touch:          [ 2, 3 ],
-    transaction:    [ 3, 4 ],
-    ttl:            [ 2, 3 ],
-    update:         [ 3, 4 ]
+    clear:             [ 1, 2 ],
+    count:             [ 1, 2 ],
+    decr:              [ 2, 3 ],
+    del:               [ 2, 3 ],
+    dump:              [ 2, 3 ],
+    empty?:            [ 1, 2 ],
+    execute:           [ 2, 3 ],
+    exists?:           [ 2, 3 ],
+    expire:            [ 3, 4 ],
+    expire_at:         [ 3, 4 ],
+    fetch:          [ 2, 3, 4 ],
+    get:               [ 2, 3 ],
+    get_and_update:    [ 3, 4 ],
+    incr:              [ 2, 3 ],
+    inspect:              [ 2 ],
+    invoke:            [ 3, 4 ],
+    keys:              [ 1, 2 ],
+    load:              [ 2, 3 ],
+    persist:           [ 2, 3 ],
+    purge:             [ 1, 2 ],
+    refresh:           [ 2, 3 ],
+    reset:             [ 1, 2 ],
+    set:               [ 3, 4 ],
+    size:              [ 1, 2 ],
+    stats:             [ 1, 2 ],
+    stream:            [ 1, 2 ],
+    take:              [ 2, 3 ],
+    touch:             [ 2, 3 ],
+    transaction:       [ 3, 4 ],
+    ttl:               [ 2, 3 ],
+    update:            [ 3, 4 ]
   ]
 
   @doc """
@@ -688,10 +688,14 @@ defmodule Cachex do
 
   """
   @spec fetch(cache, any, function, Keyword.t) :: { status | :commit | :ignore, any }
-  def fetch(cache, key, fallback, options \\ [])
-  when is_function(fallback) and is_list(options) do
+  def fetch(cache, key, fallback \\ nil, options \\ []) when is_list(options) do
     Overseer.enforce(cache) do
-      Actions.Fetch.execute(cache, key, fallback, options)
+      case fallback || cache.fallback.action do
+        val when is_function(val) ->
+          Actions.Fetch.execute(cache, key, val, options)
+        _na ->
+          @error_invalid_fallback
+      end
     end
   end
 

--- a/lib/cachex/hook.ex
+++ b/lib/cachex/hook.ex
@@ -84,10 +84,7 @@ defmodule Cachex.Hook do
       # Allow overrides of everything *except* the handle_event implementation.
       # We reserve that for internal use in order to make Hook definitions as
       # straightforward as possible.
-      defoverridable [
-        init: 1,
-        handle_notify: 3
-      ]
+      defoverridable [ init: 1, handle_notify: 3 ]
     end
   end
 

--- a/test/cachex/actions/fetch_test.exs
+++ b/test/cachex/actions/fetch_test.exs
@@ -9,12 +9,16 @@ defmodule Cachex.Actions.FetchTest do
     # create a forwarding hook
     hook = ForwardHook.create(%{ results: true })
 
+    # create a default fetch action
+    concat = &(&1 <> "_" <> &2)
+
     # create a test cache
     cache1 = Helper.create_cache([ hooks: [ hook ] ])
     cache2 = Helper.create_cache([
       hooks: [ hook ],
       fallback: [
-        state: "val"
+        state: "val",
+        action: concat
       ]
     ])
 
@@ -53,11 +57,8 @@ defmodule Cachex.Actions.FetchTest do
     assert(result4 == { :commit, "4yek" })
     assert(result5 == { :ignore, "5yek" })
 
-    # define fallback using two args
-    fb_opt4 = &(&1 <> "_" <> &2)
-
-    # test using a fallback state
-    result6 = Cachex.fetch(cache2, "key6", fb_opt4)
+    # test using a default fallback state
+    result6 = Cachex.fetch(cache2, "key6")
 
     # verify that it executes and ignores state
     assert(result6 == { :commit, "key6_val" })
@@ -68,7 +69,7 @@ defmodule Cachex.Actions.FetchTest do
     assert_receive({ { :fetch, [ "key3", ^fb_opt1, [ ] ] }, ^result3 })
     assert_receive({ { :fetch, [ "key4", ^fb_opt2, [ ] ] }, ^result4 })
     assert_receive({ { :fetch, [ "key5", ^fb_opt3, [ ] ] }, ^result5 })
-    assert_receive({ { :fetch, [ "key6", ^fb_opt4, [ ] ] }, ^result6 })
+    assert_receive({ { :fetch, [ "key6",  ^concat, [ ] ] }, ^result6 })
 
     # check we received valid purge actions for the TTL
     assert_receive({ { :purge, [[]] }, { :ok, 1 } })
@@ -84,5 +85,13 @@ defmodule Cachex.Actions.FetchTest do
 
     # ignored keys should not exist
     assert(value3 == { :missing, nil })
+
+    # check using a missing fallback
+    result7 = Cachex.fetch(cache1, "key7")
+    result8 = Cachex.fetch(cache1, "key8", "val")
+
+    # both should be an error for invalid function
+    assert(result7 == { :error, :invalid_fallback })
+    assert(result8 == { :error, :invalid_fallback })
   end
 end

--- a/test/cachex_test.exs
+++ b/test/cachex_test.exs
@@ -1,5 +1,6 @@
 defmodule CachexTest do
   use CachexCase
+  import Integer
 
   # Ensures that we're able to start a cache and link it to the current process.
   # We verify the link by spawning a cache from inside another thread and making
@@ -211,8 +212,11 @@ defmodule CachexTest do
       |> Cachex.__info__
       |> Keyword.drop([ :child_spec, :init, :start, :start_link ])
 
+    # it has to always be even (one signature creates ! versions)
+    assert(is_even(length(definitions)))
+
     # verify the size to cause errors on addition/removal
-    assert(length(definitions) == 122)
+    assert(length(definitions) == 124)
 
     # validate all definitions
     for { name, arity } <- definitions do


### PR DESCRIPTION
This fixes #129.

We're keeping the default fallback behaviour to ease migration, and it operates on `fetch/2` only. This will just use an explicit function, or the one from the cache state if missing. If both are missing, an error will be returned. 