### PR TITLE
Add options to the Limit structures

### DIFF
--- a/lib/cachex/errors.ex
+++ b/lib/cachex/errors.ex
@@ -10,6 +10,7 @@ defmodule Cachex.Errors do
       @error_invalid_command    { :error, :invalid_command }
       @error_invalid_fallback   { :error, :invalid_fallback }
       @error_invalid_hook       { :error, :invalid_hook }
+      @error_invalid_limit      { :error, :invalid_limit }
       @error_invalid_match      { :error, :invalid_match }
       @error_invalid_name       { :error, :invalid_name }
       @error_invalid_option     { :error, :invalid_option }
@@ -37,6 +38,8 @@ defmodule Cachex.Errors do
     do: "Invalid hook definition provided"
   def long_form(:invalid_fallback),
     do: "Invalid fallback function provided"
+  def long_form(:invalid_limit),
+    do: "Invalid limit fields provided"
   def long_form(:invalid_match),
     do: "Invalid match specification provided"
   def long_form(:invalid_name),

--- a/lib/cachex/limit.ex
+++ b/lib/cachex/limit.ex
@@ -12,7 +12,8 @@ defmodule Cachex.Limit do
   defstruct [
     limit:   nil,               # the limit to apply (entry count)
     policy:  Policy.LRW,        # the module to handle
-    reclaim: 0.1                # the amount of the cache to reclaim
+    reclaim: 0.1,               # the amount of the cache to reclaim
+    options: []                 # arbitrary options to pass to the hook
   ]
 
   # our opaque type
@@ -28,10 +29,15 @@ defmodule Cachex.Limit do
   Acceptable values are a preconstructed limit, or a maximum count. In the latter
   case, the LRW policy will be used with a 10% reclaim space.
   """
-  def parse(%__MODULE__{ limit: limit, policy: policy, reclaim: reclaim }),
-    do: parse_limit(limit, policy, reclaim)
+  def parse(%__MODULE__{ } = mod) do
+    with :ok <- v_parse(mod,   :limit, &(is_nil(&1) || (is_number(&1) and &1 > 0))),
+         :ok <- v_parse(mod,  :policy, &Policy.valid?/1),
+         :ok <- v_parse(mod, :reclaim, &(is_number(&1) and &1 > 0 and &1 <= 1)),
+         :ok <- v_parse(mod, :options, &Keyword.keyword?/1),
+     do: { :ok, mod }
+  end
   def parse(limit),
-    do: parse_limit(limit)
+    do: parse(%__MODULE__{ limit: limit })
 
   @doc """
   Converts a Limit struct to the required Hook form.
@@ -41,29 +47,23 @@ defmodule Cachex.Limit do
   """
   def to_hooks(%__MODULE__{ limit: nil }),
     do: []
-  def to_hooks(%__MODULE__{ limit: limit, policy: policy, reclaim: reclaim }),
+  def to_hooks(%__MODULE__{ policy: policy } = limit),
     do: [
       %Cachex.Hook{
-        args: { limit, reclaim },
+        args: limit,
         module: policy,
         provide: [ :cache ],
         type: :post
       }
     ]
 
-  # Internal parser for a Limit to ensure that we don't waste any cycles checking
-  # the same constraints multiple times. We apply defaults for any values which
-  # don't fit the necessary criteria.
-  defp parse_limit(limit, policy \\ Policy.LRW, reclaim \\ 0.1) do
-    %__MODULE__{
-      limit:   v_parse(:limit,   limit,   &(is_number(&1) and &1 > 0)),
-      policy:  v_parse(:policy,  policy,  &Policy.valid?/1),
-      reclaim: v_parse(:reclaim, reclaim, &(is_number(&1) and &1 > 0 and &1 <= 1))
-    }
-  end
-
   # Internal value parser which falls back to using defaults in the scenario the
   # provided value is invalid based upon the provided condition.
-  defp v_parse(key, val, condition),
-    do: condition.(val) && val || Map.get(%__MODULE__{ }, key)
+  defp v_parse(mod, key, condition) do
+    value = Map.fetch!(mod, key)
+    case condition.(value) do
+      true  -> :ok
+      false -> { :error, :invalid_limit }
+    end
+  end
 end

--- a/lib/cachex/options.ex
+++ b/lib/cachex/options.ex
@@ -142,7 +142,6 @@ defmodule Cachex.Options do
     options
     |> Keyword.get(:limit)
     |> Limit.parse
-    |> Util.wrap(:ok)
   end
 
   # Parses out whether the user wishes to disable on-demand expirations or not. It

--- a/test/cachex/errors_test.exs
+++ b/test/cachex/errors_test.exs
@@ -8,6 +8,7 @@ defmodule Cachex.ErrorsTest do
     errors = [
       invalid_command:   "Invalid command definition provided",
       invalid_hook:      "Invalid hook definition provided",
+      invalid_limit:     "Invalid limit fields provided",
       invalid_match:     "Invalid match specification provided",
       invalid_name:      "Invalid cache name provided",
       invalid_option:    "Invalid option syntax provided",
@@ -28,5 +29,4 @@ defmodule Cachex.ErrorsTest do
       assert(long_form == msg)
     end
   end
-
 end

--- a/test/cachex/options_test.exs
+++ b/test/cachex/options_test.exs
@@ -210,8 +210,8 @@ defmodule Cachex.OptionsTest do
     { :ok, state2 } = Cachex.Options.parse(name, [ limit: c_limits ])
 
     # parse options with invalid max_size
-    { :ok, state3 } = Cachex.Options.parse(name, [ limit: "max_size" ])
-    { :ok, state4 } = Cachex.Options.parse(name, [ ])
+    { :ok, state3 } = Cachex.Options.parse(name, [ ])
+           state4   = Cachex.Options.parse(name, [ limit: "max_size" ])
 
     # check the first and second states have limits
     assert(state1.limit == c_limits)
@@ -219,11 +219,12 @@ defmodule Cachex.OptionsTest do
     assert(state1.post_hooks == Cachex.Limit.to_hooks(c_limits))
     assert(state2.post_hooks == Cachex.Limit.to_hooks(c_limits))
 
-    # check the third and fourth states have no limits
+    # check the third has no limits attached
     assert(state3.limit == default)
-    assert(state4.limit == default)
     assert(state3.post_hooks == [])
-    assert(state4.post_hooks == [])
+
+    # check the fourth causes an error
+    assert(state4 == { :error, :invalid_limit })
   end
 
   # On-Demand expiration can be disabled, and so we have to parse out whether the

--- a/test/cachex/policy/lrw_test.exs
+++ b/test/cachex/policy/lrw_test.exs
@@ -38,7 +38,8 @@ defmodule Cachex.Policy.LRWTest do
     limit = %Cachex.Limit{
       limit: 100,
       policy: Cachex.Policy.LRW,
-      reclaim: 0.75
+      reclaim: 0.75,
+      options: [ batch_size: 25 ]
     }
 
     # create a cache with a max size


### PR DESCRIPTION
This fixes #141.

This PR will add support for arbitrary options being passed to Limit structures; this is done to allow the `batch_size` option being passed through to the LRW policy to control the size of batches being deleted. It will now default to 100, but can be configured manually if needed. Options are specific to each policy, to avoid coupling them all together.