### PR TITLE
Introduce the notion of synchronized fallbacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,18 @@ language: elixir
 elixir:
   - 1.5.2
   - 1.4.5
+  - 1.3.4
+  - 1.2.6
 otp_release:
   - 20.1
   - 19.3
   - 18.3
+matrix:
+  exclude:
+  - elixir: 1.3.4
+    otp_release: 20.1
+  - elixir: 1.2.6
+    otp_release: 20.1
 branches:
   only:
   - master

--- a/lib/cachex/services.ex
+++ b/lib/cachex/services.ex
@@ -49,6 +49,7 @@ defmodule Cachex.Services do
     |> Enum.concat(table_spec(cache))
     |> Enum.concat(locksmith_spec(cache))
     |> Enum.concat(informant_spec(cache))
+    |> Enum.concat(courier_spec(cache))
     |> Enum.concat(janitor_spec(cache))
     |> Enum.concat(limit_spec(cache))
   end
@@ -56,6 +57,14 @@ defmodule Cachex.Services do
   ###############
   # Private API #
   ###############
+
+  # Creates a specification for the Courier service.
+  #
+  # The courier acts as a synchronised way to retrieve values computed via
+  # fallback functions to avoid clashing. Each cache should have a courier
+  # by default as fallbacks are enabled by default (not behind a flag).
+  defp courier_spec(cache() = cache),
+    do: [ worker(Services.Courier, [ cache ]) ]
 
   # Creates a specification for the Informant supervisor.
   #

--- a/lib/cachex/services/courier.ex
+++ b/lib/cachex/services/courier.ex
@@ -1,0 +1,107 @@
+defmodule Cachex.Services.Courier do
+  @moduledoc """
+  Dispatch service to retrieve values from remote calls.
+
+  The Courier provides the main implementation for fallbacks triggered
+  by calls to the `fetch()` command. It acts as a synchronized execution
+  for tasks to avoid duplicating calls when loading.
+
+  The Courier uses a very simple algorithm to determine when to execute
+  a fallback, so there's very little overhead to synchronizing calls
+  through it. As tasks are dispatched via spawned processes, there's
+  very little action actually happening in the service process itself.
+  """
+  use GenServer
+
+  # import spec macros
+  import Cachex.Spec
+
+  # add some aliases
+  alias Cachex.Actions.Set
+  alias Cachex.Util
+
+  ##############
+  # Public API #
+  ##############
+
+  @doc """
+  Starts a new Courier process for a cache.
+  """
+  @spec start_link(Spec.cache) :: GenServer.on_start
+  def start_link(cache(name: name) = cache),
+    do: GenServer.start_link(__MODULE__, cache, [ name: name(name, :courier) ])
+
+  @doc """
+  Dispatches the Courier to execute a task.
+
+  The task provided must be a closure with arity 0, in order to
+  simplify the interfaces internally. This is a blocking remote
+  call which will wait until a result can be loaded.
+  """
+  @spec dispatch(Spec.cache, any, (() -> any)) :: any
+  def dispatch(cache() = cache, key, task) when is_function(task, 0),
+    do: service_call(cache, :courier, { :dispatch, key, task })
+
+  ####################
+  # Server Callbacks #
+  ####################
+
+  @doc false
+  # Initializes a Courier service using a cache record.
+  #
+  # This will create a Tuple to store the cache record as well
+  # as the Map used to track the internal task referencing.
+  def init(cache),
+    do: { :ok, { cache, %{ } } }
+
+  @doc false
+  # Dispatches a tasks to be carried out by the Courier.
+  #
+  # Tasks will only be executed if they're not already in progress. This
+  # is only tracked on a key level, so it's not possible to track different
+  # tasks for a given key.
+  #
+  # Due to the nature of the async behaviour, this call will return before
+  # the task has been completed, and the :notify callback will receive the
+  # results from the task after completion (regardless of outcome).
+  def handle_call({ :dispatch, key, task }, caller, { cache, tasks }) do
+    references =
+      case Map.get(tasks, key, []) do
+        [] ->
+          parent = self()
+          spawn(fn ->
+            result =
+              try do
+                task.()
+              rescue
+                e -> { :error, Exception.message(e) }
+              end
+            send(parent, { :notify, key, result })
+          end)
+          [ caller ]
+        li ->
+          [ caller | li ]
+      end
+
+    { :noreply, { cache, Map.put(tasks, key, references) } }
+  end
+
+  @doc false
+  # Receives a notification of a previously completed task.
+  #
+  # This will update all processes waiting for the result of the
+  # specified task, and remove the task from the tracked state.
+  def handle_info({ :notify, key, result }, { cache, tasks }) do
+    normalized = Util.normalize_commit(result)
+
+    with { :commit, val } <- normalized do
+      Set.execute(cache, key, val, const(:notify_false))
+    end
+
+    for caller <- Map.get(tasks, key, []) do
+      GenServer.reply(caller, normalized)
+    end
+
+    { :noreply, { cache, Map.delete(tasks, key) } }
+  end
+end

--- a/lib/cachex/services/janitor.ex
+++ b/lib/cachex/services/janitor.ex
@@ -44,11 +44,8 @@ defmodule Cachex.Services.Janitor do
   @spec last_run(Spec.cache) :: %{}
   def last_run(cache(expiration: expiration(interval: nil))),
     do: error(:janitor_disabled)
-  def last_run(cache(name: name)) do
-    name
-    |> name(:janitor)
-    |> GenServer.call(:last)
-  end
+  def last_run(cache() = cache),
+    do: service_call(cache, :janitor, :last)
 
   ####################
   # Server Callbacks #

--- a/lib/cachex/util.ex
+++ b/lib/cachex/util.ex
@@ -20,9 +20,15 @@ defmodule Cachex.Util do
   # the number of suffixes stored (not including B)
   @memory_sufcount map_size(@memory_suffixes) - 1.0
 
+  # available result tuple tag list
+  @result_tags [ :commit, :ignore, :error ]
+
   ##############
   # Public API #
   ##############
+
+  # result tuple tag type
+  @type result_tag :: :commit | :ignore | :error
 
   @doc """
   Converts a number of bytes to a binary representation.
@@ -116,12 +122,13 @@ defmodule Cachex.Util do
     do: false
 
   @doc """
-  Normalizes a commit result to a Tuple tagged with `:commit` or `:ignore`.
+  Normalizes a commit result to a Tuple tagged with `:commit`, `:ignore`
+  or `:error`.
   """
-  @spec normalize_commit({ :commit | :ignore, any } | any) :: { :commit | :ignore, any }
+  @spec normalize_commit({ result_tag, any } | any) :: { result_tag, any }
   def normalize_commit(value) do
     case value do
-      { status, _val } when status in [ :commit, :ignore ] ->
+      { status, _val } when status in @result_tags ->
         value
       ^value ->
         { :commit, value }

--- a/mix.exs
+++ b/mix.exs
@@ -45,6 +45,7 @@ defmodule Cachex.Mixfile do
         tool: ExCoveralls
       ],
       preferred_cli_env: [
+        "docs": :docs,
         "cachex": :test,
         "coveralls": :test,
         "coveralls.html": :test,
@@ -78,12 +79,13 @@ defmodule Cachex.Mixfile do
       { :eternal, "~> 1.1" },
       { :unsafe,  "~> 1.0" },
       # Local dependencies
-      { :benchfella,  "~> 0.3",  optional: true, only: [ :dev, :test ] },
-      { :bmark,       "~> 1.0",  optional: true, only: [ :dev, :test ] },
-      { :credo,       "~> 0.8",  optional: true, only: [ :dev, :test ] },
-      { :ex_doc,      "~> 0.16", optional: true, only: [ :dev, :test ] },
-      { :excoveralls, "~> 0.7",  optional: true, only: [ :dev, :test ] },
-      { :exprof,      "~> 0.2",  optional: true, only: [ :dev, :test ] }
+      { :benchfella,  "~> 0.3", optional: true, only: [ :dev, :test ] },
+      { :bmark,       "~> 1.0", optional: true, only: [ :dev, :test ] },
+      { :credo,       "~> 0.8", optional: true, only: [ :dev, :test ] },
+      { :excoveralls, "~> 0.7", optional: true, only: [ :dev, :test ] },
+      { :exprof,      "~> 0.2", optional: true, only: [ :dev, :test ] },
+      # Documentation dependencies
+      { :ex_doc, "~> 0.16", optional: true, only: [ :docs ] }
     ]
   end
 end

--- a/test/cachex/services/courier_test.exs
+++ b/test/cachex/services/courier_test.exs
@@ -1,0 +1,72 @@
+defmodule Cachex.Services.CourierTest do
+  use CachexCase
+
+  test "dispatching tasks" do
+    # start a new cache
+    cache = Helper.create_cache()
+    cache = Services.Overseer.retrieve(cache)
+
+    # dispatch an arbitrary task
+    result = Services.Courier.dispatch(cache, "my_key", fn ->
+      "my_value"
+    end)
+
+    # check the returned value
+    assert result == { :commit, "my_value" }
+
+    # check the key was placed in the table
+    retrieved = Cachex.get(cache, "my_key")
+
+    # the retrieved value should match
+    assert retrieved == { :ok, "my_value" }
+  end
+
+  test "dispatching tasks from multiple processes" do
+    # create a hook for forwarding
+    { :ok, agent } = Agent.start_link(fn -> :ok end)
+
+    # define our task function
+    task = fn ->
+      :timer.sleep(250) && "my_value"
+    end
+
+    # start a new cache
+    cache = Helper.create_cache()
+    cache = Services.Overseer.retrieve(cache)
+    parent = self()
+
+    # dispatch an arbitrary task from the agent process
+    Agent.cast(agent, fn _ ->
+      send(parent, Services.Courier.dispatch(cache, "my_key", task))
+    end)
+
+    # dispatch an arbitrary task from the current process
+    result = Services.Courier.dispatch(cache, "my_key", task)
+
+    # check the forwarded task completed
+    assert_receive({ :commit, "my_value" })
+
+    # check the returned value
+    assert result == { :commit, "my_value" }
+
+    # check the key was placed in the table
+    retrieved = Cachex.get(cache, "my_key")
+
+    # the retrieved value should match
+    assert retrieved == { :ok, "my_value" }
+  end
+
+  test "gracefully handling crashes inside tasks" do
+    # start a new cache
+    cache = Helper.create_cache()
+    cache = Services.Overseer.retrieve(cache)
+
+    # dispatch an arbitrary task
+    result = Services.Courier.dispatch(cache, "my_key", fn ->
+      raise ArgumentError
+    end)
+
+    # check the returned value
+    assert result == { :error, "argument error" }
+  end
+end

--- a/test/cachex/services_test.exs
+++ b/test/cachex/services_test.exs
@@ -18,6 +18,7 @@ defmodule Cachex.ServicesTest do
       { Eternal, _, _, _, _, _ },
       { Services.Locksmith.Queue, _, _, _, _, _ },
       { Services.Informant, _, _, _, _, _ },
+      { Services.Courier, _, _, _, _, _ },
       { Services.Janitor, _, _, _, _, _ }
     ] = Services.cache_spec(cache)
   end
@@ -32,6 +33,7 @@ defmodule Cachex.ServicesTest do
       { Eternal, _, _, _, _, _ },
       { Services.Locksmith.Queue, _, _, _, _, _ },
       { Services.Informant, _, _, _, _, _ },
+      { Services.Courier, _, _, _, _, _ },
       { Services.Janitor, _, _, _, _, _ },
       { Supervisor, { Supervisor, _, [ [ { __MODULE__.TestPolicy, _, _, _, _, _ } ], _ ] }, _, _, _, _ }
     ] = Services.cache_spec(cache)
@@ -46,7 +48,8 @@ defmodule Cachex.ServicesTest do
     assert [
       { Eternal, _, _, _, _, _ },
       { Services.Locksmith.Queue, _, _, _, _, _ },
-      { Services.Informant, _, _, _, _, _ }
+      { Services.Informant, _, _, _, _, _ },
+      { Services.Courier, _, _, _, _, _ },
     ] = Services.cache_spec(cache)
   end
 

--- a/test/cachex/util_test.exs
+++ b/test/cachex/util_test.exs
@@ -145,6 +145,7 @@ defmodule Cachex.UtilTest do
     # define our base Tuples to test against
     tuple1 = { :commit, true }
     tuple2 = { :ignore, true }
+    tuple3 = { :error,  true }
 
     # define our base value
     value1 = true
@@ -152,14 +153,16 @@ defmodule Cachex.UtilTest do
     # normalize all values
     result1 = Cachex.Util.normalize_commit(tuple1)
     result2 = Cachex.Util.normalize_commit(tuple2)
-    result3 = Cachex.Util.normalize_commit(value1)
+    result3 = Cachex.Util.normalize_commit(tuple3)
+    result4 = Cachex.Util.normalize_commit(value1)
 
-    # the first two should persist
+    # the first three should persist
     assert(result1 == tuple1)
     assert(result2 == tuple2)
+    assert(result3 == tuple3)
 
     # the value should be converted to the first
-    assert(result3 == tuple1)
+    assert(result4 == tuple1)
   end
 
   # This test just provides basic coverage of the write_mod function, by using


### PR DESCRIPTION
This fixes #96. 

This will introduce a new courier service which will only execute a single fallback for a given key at once, rather than running multiple on top of each other. If a fallback executes whilst one is in progress, it will simply await the result of the existing task.

This does not allow the case where multiple fetches on the same key execute at the same time but with different fallback functions, but this is such an anti-pattern that I doubt it'll ever be an issue. There's a way to solve this by re-queuing tasks that have a different function (which also means we need to move to `apply()`), but it's more complicated and less performant... so we'll only do as necessary (i.e. if people request it often enough). 