### PR TITLE
Remember to import Cachex.Spec when using limit record

### DIFF
--- a/docs/cache-limits.md
+++ b/docs/cache-limits.md
@@ -11,6 +11,7 @@ Limits are defined at cache startup and cannot be changed at this point in time.
 Cachex.start(:my_cache, [ limit: 500 ])
 
 # maximum 500 entries, LRW eviction, trim to 250
+import Cachex.Spec
 Cachex.start(:my_cache, [ limit: limit(size: 500, policy: Cachex.Policy.LRW, reclaim: 0.5) ])
 ```
 


### PR DESCRIPTION
Hi, great lib. Took me a moment to realize where is that limit() coming from so I wanted to save that moment for other people.

I also needed to use github version in my mix.env, I'm assuming it's just that the mix version is out of date? Would be nice to bump a version and push since most people will use doc pages linked in README.

Keep up the great work.