### PR TITLE
Migate Cachex.set/4 to Cachex.put/4

### DIFF
--- a/docs/action-blocks.md
+++ b/docs/action-blocks.md
@@ -29,7 +29,7 @@ It's very important to note that even though you're executing a block, other act
 # start our execution block
 Cachex.execute!(:my_cache, fn(cache) ->
   # set a base value in the cache
-  Cachex.set!(cache, "key", "value")
+  Cachex.put!(cache, "key", "value")
   # we're paused but other stuff can happen
   :timer.sleep(5000)
   # this may have have been set elsewhere by this point
@@ -47,7 +47,7 @@ One of the most useful blocks is the transactional block. These blocks will bind
 # start our execution block
 Cachex.transaction!(:my_cache, [ "key" ], fn(cache) ->
   # set a base value in the cache
-  Cachex.set!(cache, "key", "value")
+  Cachex.put!(cache, "key", "value")
   # we're paused but other stuff can not happen
   :timer.sleep(5000)
   # this will be guaranteed to return "value"

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -53,7 +53,7 @@ Cachex.start_link(:my_cache, [
   commands: [ lpop: command(type: :write, execute: lpop) ]
 ])
 
-{ :ok, true } = Cachex.set(:my_cache, "my_list", [ 1, 2, 3 ])
+{ :ok, true } = Cachex.put(:my_cache, "my_list", [ 1, 2, 3 ])
 { :ok,    1 } = Cachex.invoke(:my_cache, "my_list", :lpop)
 { :ok,    2 } = Cachex.invoke(:my_cache, "my_list", :lpop)
 { :ok,    3 } = Cachex.invoke(:my_cache, "my_list", :lpop)

--- a/docs/disk-interaction.md
+++ b/docs/disk-interaction.md
@@ -9,7 +9,7 @@ To use a dump to seed a new cache, you can use the `load/2` function. Please not
 ```elixir
 # set some values in a cache
 :ok = Enum.each(1..5, fn(x) ->
-  { :ok, true } = Cachex.set(:my_cache, x, x)
+  { :ok, true } = Cachex.put(:my_cache, x, x)
 end)
 
 # verify the size of the cache == 5

--- a/docs/migrating-to-v2.x.md
+++ b/docs/migrating-to-v2.x.md
@@ -105,7 +105,7 @@ The first change is down to optimizations of key locking, and requires that you 
 Cachex.transaction(:my_cache, [ "key1" ], fn(state) ->
   old_val = Cachex.get!("key1")
   new_val = do_something(old_val)
-  Cachex.set!("key1", new_val)
+  Cachex.put!("key1", new_val)
 end)
 ```
 

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -81,6 +81,8 @@ defmodule Cachex do
     load:              [ 2, 3 ],
     persist:           [ 2, 3 ],
     purge:             [ 1, 2 ],
+    put:               [ 3, 4 ],
+    put_many:          [ 2, 3 ],
     refresh:           [ 2, 3 ],
     reset:             [ 1, 2 ],
     set:               [ 3, 4 ],
@@ -319,7 +321,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key", "value")
+      iex> Cachex.put(:my_cache, "key", "value")
       iex> Cachex.get(:my_cache, "key")
       iex> Cachex.size(:my_cache)
       { :ok, 1 }
@@ -348,9 +350,9 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key1", "value1")
-      iex> Cachex.set(:my_cache, "key2", "value2")
-      iex> Cachex.set(:my_cache, "key3", "value3")
+      iex> Cachex.put(:my_cache, "key1", "value1")
+      iex> Cachex.put(:my_cache, "key2", "value2")
+      iex> Cachex.put(:my_cache, "key3", "value3")
       iex> Cachex.count(:my_cache)
       { :ok, 3 }
 
@@ -378,11 +380,11 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "my_key", 10)
+      iex> Cachex.put(:my_cache, "my_key", 10)
       iex> Cachex.decr(:my_cache, "my_key")
       { :ok, 9 }
 
-      iex> Cachex.set(:my_cache, "my_new_key", 10)
+      iex> Cachex.put(:my_cache, "my_new_key", 10)
       iex> Cachex.decr(:my_cache, "my_new_key", 5)
       { :ok, 5 }
 
@@ -405,7 +407,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key", "value")
+      iex> Cachex.put(:my_cache, "key", "value")
       iex> Cachex.get(:my_cache, "key")
       { :ok, "value" }
 
@@ -447,7 +449,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "my_key", 10)
+      iex> Cachex.put(:my_cache, "my_key", 10)
       iex> Cachex.dump(:my_cache, "/tmp/my_default_backup")
       { :ok, true }
 
@@ -472,7 +474,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key1", "value1")
+      iex> Cachex.put(:my_cache, "key1", "value1")
       iex> Cachex.empty?(:my_cache)
       { :ok, false }
 
@@ -506,8 +508,8 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key1", "value1")
-      iex> Cachex.set(:my_cache, "key2", "value2")
+      iex> Cachex.put(:my_cache, "key1", "value1")
+      iex> Cachex.put(:my_cache, "key2", "value2")
       iex> Cachex.execute(:my_cache, fn(worker) ->
       ...>   val1 = Cachex.get!(worker, "key1")
       ...>   val2 = Cachex.get!(worker, "key2")
@@ -532,7 +534,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key", "value")
+      iex> Cachex.put(:my_cache, "key", "value")
       iex> Cachex.exists?(:my_cache, "key")
       { :ok, true }
 
@@ -558,7 +560,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key", "value")
+      iex> Cachex.put(:my_cache, "key", "value")
       iex> Cachex.expire(:my_cache, "key", :timer.seconds(5))
       { :ok, true }
 
@@ -583,7 +585,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key", "value")
+      iex> Cachex.put(:my_cache, "key", "value")
       iex> Cachex.expire_at(:my_cache, "key", 1455728085502)
       { :ok, true }
 
@@ -629,7 +631,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key", "value")
+      iex> Cachex.put(:my_cache, "key", "value")
       iex> Cachex.fetch(:my_cache, "key", fn(key) ->
       ...>   { :commit, String.reverse(key) }
       ...> end)
@@ -663,7 +665,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key", "value")
+      iex> Cachex.put(:my_cache, "key", "value")
       iex> Cachex.get(:my_cache, "key")
       { :ok, "value" }
 
@@ -691,7 +693,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key", [2])
+      iex> Cachex.put(:my_cache, "key", [2])
       iex> Cachex.get_and_update(:my_cache, "key", &([1|&1]))
       { :ok, [1, 2] }
 
@@ -717,9 +719,9 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key1", "value1")
-      iex> Cachex.set(:my_cache, "key2", "value2")
-      iex> Cachex.set(:my_cache, "key3", "value3")
+      iex> Cachex.put(:my_cache, "key1", "value1")
+      iex> Cachex.put(:my_cache, "key2", "value2")
+      iex> Cachex.put(:my_cache, "key3", "value3")
       iex> Cachex.keys(:my_cache)
       { :ok, [ "key2", "key1", "key3" ] }
 
@@ -751,11 +753,11 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "my_key", 10)
+      iex> Cachex.put(:my_cache, "my_key", 10)
       iex> Cachex.incr(:my_cache, "my_key")
       { :ok, 11 }
 
-      iex> Cachex.set(:my_cache, "my_new_key", 10)
+      iex> Cachex.put(:my_cache, "my_new_key", 10)
       iex> Cachex.incr(:my_cache, "my_new_key", 5)
       { :ok, 15 }
 
@@ -888,7 +890,7 @@ defmodule Cachex do
       ...>      last: command(type: :read, execute: &List.last/1)
       ...>    ]
       ...> ])
-      iex> Cachex.set(:my_cache, "my_list", [ 1, 2, 3 ])
+      iex> Cachex.put(:my_cache, "my_list", [ 1, 2, 3 ])
       iex> Cachex.invoke(:my_cache, "my_list", :last)
       { :ok, 3 }
 
@@ -912,7 +914,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "my_key", 10)
+      iex> Cachex.put(:my_cache, "my_key", 10)
       iex> Cachex.dump(:my_cache, "/tmp/my_backup")
       iex> Cachex.clear(:my_cache)
       iex> Cachex.load(:my_cache, "/tmp/my_backup")
@@ -932,7 +934,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key", "value", ttl: 1000)
+      iex> Cachex.put(:my_cache, "key", "value", ttl: 1000)
       iex> Cachex.persist(:my_cache, "key")
       { :ok, true }
 
@@ -966,6 +968,73 @@ defmodule Cachex do
   end
 
   @doc """
+  Places an entry in a cache.
+
+  This will overwrite any value that was previously set against the provided key,
+  and overwrite any TTLs which were already set.
+
+  ## Options
+
+    * `:ttl`
+
+      </br>
+      An expiration time to set for the provided key (time-to-line), overriding
+      any default expirations set on a cache. This value should be in milliseconds.
+
+  ## Examples
+
+      iex> Cachex.put(:my_cache, "key", "value")
+      { :ok, true }
+
+      iex> Cachex.put(:my_cache, "key", "value", ttl: :timer.seconds(5))
+      iex> Cachex.ttl(:my_cache, "key")
+      { :ok, 5000 }
+
+  """
+  # TODO: maybe rename TTL to be expiration?
+  @spec put(cache, any, any, Keyword.t) :: { status, boolean }
+  def put(cache, key, value, options \\ []) when is_list(options) do
+    Overseer.enforce(cache) do
+      Actions.Put.execute(cache, key, value, options)
+    end
+  end
+
+  @doc """
+  Places a batch of entries in a cache.
+
+  This operates in the same way as `put/4`, except that multiple keys can be
+  inserted in a single atomic batch. This is a performance gain over writing
+  keys using multiple calls to `put/4`, however it's a performance penalty
+  when writing a single key pair due to some batching overhead.
+
+  ## Options
+
+    * `:ttl`
+
+      </br>
+      An expiration time to set for the provided keys (time-to-line), overriding
+      any default expirations set on a cache. This value should be in milliseconds.
+
+  ## Examples
+
+      iex> Cachex.put_many(:my_cache, [ { "key", "value" } ])
+      { :ok, true }
+
+      iex> Cachex.put_many(:my_cache, [ { "key", "value" } ], ttl: :timer.seconds(5))
+      iex> Cachex.ttl(:my_cache, "key")
+      { :ok, 5000 }
+
+  """
+  # TODO: maybe rename TTL to be expiration?
+  @spec put_many(cache, [ { any, any } ], Keyword.t) :: { status, boolean }
+  def put_many(cache, pairs, options \\ [])
+  when is_list(pairs) and is_list(options) do
+    Overseer.enforce(cache) do
+      Actions.PutMany.execute(cache, pairs, options)
+    end
+  end
+
+  @doc """
   Refreshes an expiration for an entry in a cache.
 
   Refreshing an expiration will reset the existing expiration with an offset
@@ -975,7 +1044,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "my_key", "my_value", ttl: :timer.seconds(5))
+      iex> Cachex.put(:my_cache, "my_key", "my_value", ttl: :timer.seconds(5))
       iex> :timer.sleep(4)
       iex> Cachex.ttl(:my_cache, "my_key")
       { :ok, 1000 }
@@ -1018,7 +1087,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "my_key", "my_value")
+      iex> Cachex.put(:my_cache, "my_key", "my_value")
       iex> Cachex.reset(:my_cache)
       iex> Cachex.size(:my_cache)
       { :ok, 0 }
@@ -1040,72 +1109,15 @@ defmodule Cachex do
     end
   end
 
-  @doc """
-  Places an entry in a cache.
+  @doc false
+  # Deprecated implementation delegate of `put/4`
+  @deprecated "Please migrate to using put/4 instead"
+  defdelegate set(cache, key, value, options \\ []), to: Cachex, as: :put
 
-  This will overwrite any value that was previously set against the provided key,
-  and overwrite any TTLs which were already set.
-
-  ## Options
-
-    * `:ttl`
-
-      </br>
-      An expiration time to set for the provided key (time-to-line), overriding
-      any default expirations set on a cache. This value should be in milliseconds.
-
-  ## Examples
-
-      iex> Cachex.set(:my_cache, "key", "value")
-      { :ok, true }
-
-      iex> Cachex.set(:my_cache, "key", "value", ttl: :timer.seconds(5))
-      iex> Cachex.ttl(:my_cache, "key")
-      { :ok, 5000 }
-
-  """
-  # TODO: maybe rename TTL to be expiration?
-  @spec set(cache, any, any, Keyword.t) :: { status, boolean }
-  def set(cache, key, value, options \\ []) when is_list(options) do
-    Overseer.enforce(cache) do
-      Actions.Set.execute(cache, key, value, options)
-    end
-  end
-
-  @doc """
-  Places a batch of entries in a cache.
-
-  This operates in the same way as `set/4`, except that multiple keys can be
-  inserted in a single atomic batch. This is a performance gain over writing
-  keys using multiple calls to `set/4`, however it's a performance penalty
-  when writing a single key pair due to some batching overhead.
-
-  ## Options
-
-    * `:ttl`
-
-      </br>
-      An expiration time to set for the provided keys (time-to-line), overriding
-      any default expirations set on a cache. This value should be in milliseconds.
-
-  ## Examples
-
-      iex> Cachex.set_many(:my_cache, [ { "key", "value" } ])
-      { :ok, true }
-
-      iex> Cachex.set_many(:my_cache, [ { "key", "value" } ], ttl: :timer.seconds(5))
-      iex> Cachex.ttl(:my_cache, "key")
-      { :ok, 5000 }
-
-  """
-  # TODO: maybe rename TTL to be expiration?
-  @spec set_many(cache, [ { any, any } ], Keyword.t) :: { status, boolean }
-  def set_many(cache, pairs, options \\ [])
-  when is_list(pairs) and is_list(options) do
-    Overseer.enforce(cache) do
-      Actions.SetMany.execute(cache, pairs, options)
-    end
-  end
+  @doc false
+  # Deprecated implementation delegate of `put_many/3`
+  @deprecated "Please migrate to using put_many/3 instead"
+  defdelegate set_many(cache, pairs, options \\ []), to: Cachex, as: :put_many
 
   @doc """
   Retrieves the total size of a cache.
@@ -1117,9 +1129,9 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key1", "value1")
-      iex> Cachex.set(:my_cache, "key2", "value2")
-      iex> Cachex.set(:my_cache, "key3", "value3")
+      iex> Cachex.put(:my_cache, "key1", "value1")
+      iex> Cachex.put(:my_cache, "key2", "value2")
+      iex> Cachex.put(:my_cache, "key3", "value3")
       iex> Cachex.size(:my_cache)
       { :ok, 3 }
 
@@ -1192,9 +1204,9 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "a", 1)
-      iex> Cachex.set(:my_cache, "b", 2)
-      iex> Cachex.set(:my_cache, "c", 3)
+      iex> Cachex.put(:my_cache, "a", 1)
+      iex> Cachex.put(:my_cache, "b", 2)
+      iex> Cachex.put(:my_cache, "c", 3)
       {:ok, true}
 
       iex> :my_cache |> Cachex.stream! |> Enum.to_list
@@ -1225,7 +1237,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key", "value")
+      iex> Cachex.put(:my_cache, "key", "value")
       iex> Cachex.take(:my_cache, "key")
       { :ok, "value" }
 
@@ -1268,8 +1280,8 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key1", "value1")
-      iex> Cachex.set(:my_cache, "key2", "value2")
+      iex> Cachex.put(:my_cache, "key1", "value1")
+      iex> Cachex.put(:my_cache, "key2", "value2")
       iex> Cachex.transaction(:my_cache, fn(worker) ->
       ...>   val1 = Cachex.get(worker, "key1")
       ...>   val2 = Cachex.get(worker, "key2")
@@ -1331,7 +1343,7 @@ defmodule Cachex do
 
   ## Examples
 
-      iex> Cachex.set(:my_cache, "key", "value")
+      iex> Cachex.put(:my_cache, "key", "value")
       iex> Cachex.get(:my_cache, "key")
       { :ok, "value" }
 

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -1113,13 +1113,15 @@ defmodule Cachex do
   Deprecated implementation delegate of `put/4`.
   """
   @deprecated "Please migrate to using put/4 instead"
-  defdelegate set(cache, key, value, options \\ []), to: Cachex, as: :put
+  def set(cache, key, value, options \\ []),
+    do: put(cache, key, value, options)
 
   @doc """
   Deprecated implementation delegate of `put_many/3`.
   """
   @deprecated "Please migrate to using put_many/3 instead"
-  defdelegate set_many(cache, pairs, options \\ []), to: Cachex, as: :put_many
+  def set_many(cache, pairs, options \\ []),
+    do: put_many(cache, pairs, options)
 
   @doc """
   Retrieves the total size of a cache.

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -1109,13 +1109,15 @@ defmodule Cachex do
     end
   end
 
-  @doc false
-  # Deprecated implementation delegate of `put/4`
+  @doc """
+  Deprecated implementation delegate of `put/4`.
+  """
   @deprecated "Please migrate to using put/4 instead"
   defdelegate set(cache, key, value, options \\ []), to: Cachex, as: :put
 
-  @doc false
-  # Deprecated implementation delegate of `put_many/3`
+  @doc """
+  Deprecated implementation delegate of `put_many/3`.
+  """
   @deprecated "Please migrate to using put_many/3 instead"
   defdelegate set_many(cache, pairs, options \\ []), to: Cachex, as: :put_many
 

--- a/lib/cachex/actions.ex
+++ b/lib/cachex/actions.ex
@@ -72,7 +72,7 @@ defmodule Cachex.Actions do
   """
   @spec write_mod(atom) :: atom
   def write_mod(tag) when tag in [ :missing, :new ],
-    do: __MODULE__.Set
+    do: __MODULE__.Put
   def write_mod(_tag),
     do: __MODULE__.Update
 

--- a/lib/cachex/actions/put.ex
+++ b/lib/cachex/actions/put.ex
@@ -1,4 +1,4 @@
-defmodule Cachex.Actions.Set do
+defmodule Cachex.Actions.Put do
   @moduledoc """
   Command module to enable insertion of cache entries.
 
@@ -27,7 +27,7 @@ defmodule Cachex.Actions.Set do
   This takes expiration times into account before insertion and will operate
   inside a lock aware context to avoid clashing with other processes.
   """
-  defaction set(cache() = cache, key, value, options) do
+  defaction put(cache() = cache, key, value, options) do
     ttlval = Options.get(options, :ttl, &is_integer/1)
     expiry = Janitor.expiration(cache, ttlval)
 

--- a/lib/cachex/actions/put_many.ex
+++ b/lib/cachex/actions/put_many.ex
@@ -1,4 +1,4 @@
-defmodule Cachex.Actions.SetMany do
+defmodule Cachex.Actions.PutMany do
   @moduledoc """
   Command module to enable batch insertion of cache entries.
 
@@ -29,7 +29,7 @@ defmodule Cachex.Actions.SetMany do
   This takes expiration times into account before insertion and will operate
   inside a lock aware context to avoid clashing with other processes.
   """
-  defaction set_many(cache() = cache, pairs, options) do
+  defaction put_many(cache() = cache, pairs, options) do
     ttlval = Options.get(options, :ttl, &is_integer/1)
     expiry = Janitor.expiration(cache, ttlval)
 

--- a/lib/cachex/execution_error.ex
+++ b/lib/cachex/execution_error.ex
@@ -6,7 +6,7 @@ defmodule Cachex.ExecutionError do
   block to other errors/exceptions rather than using stdlib errors.
 
       iex> try do
-      ...>   Cachex.set!(:cache, "key", "value")
+      ...>   Cachex.put!(:cache, "key", "value")
       ...> rescue
       ...>   e in Cachex.ExecutionError -> e
       ...> end

--- a/lib/cachex/policy/lrw.ex
+++ b/lib/cachex/policy/lrw.ex
@@ -46,8 +46,8 @@ defmodule Cachex.Policy.LRW do
         args: limit,
         actions: [
           :decr, :incr,
-          :set, :update,
-          :get_and_update
+          :put, :put_many,
+          :update, :get_and_update
         ],
         module: __MODULE__,
         provide: [ :cache ],

--- a/lib/cachex/services/courier.ex
+++ b/lib/cachex/services/courier.ex
@@ -18,7 +18,7 @@ defmodule Cachex.Services.Courier do
   import Cachex.Spec
 
   # add some aliases
-  alias Cachex.Actions.Set
+  alias Cachex.Actions.Put
 
   ##############
   # Public API #
@@ -95,7 +95,7 @@ defmodule Cachex.Services.Courier do
     normalized = normalize_commit(result)
 
     with { :commit, val } <- normalized do
-      Set.execute(cache, key, val, const(:notify_false))
+      Put.execute(cache, key, val, const(:notify_false))
     end
 
     for caller <- Map.get(tasks, key, []) do

--- a/lib/cachex/stats.ex
+++ b/lib/cachex/stats.ex
@@ -140,25 +140,25 @@ defmodule Cachex.Stats do
     |> increment(:global, :expiredCount, value)
   end
 
-  # Handles registration of `set()` command calls.
+  # Handles registration of `put()` command calls.
   #
-  # Set calls will increment the result of the call in the `:set`
+  # Set calls will increment the result of the call in the `:put`
   # namespace inside the statistics container. It will also
   # increment the global entry set count.
-  defp register_action(stats, { :set, _args }, { _status, value }) do
-    tmp = increment(stats, :set, value, 1)
+  defp register_action(stats, { :put, _args }, { _status, value }) do
+    tmp = increment(stats, :put, value, 1)
     case value do
       true  -> increment(tmp, :global, :setCount, 1)
       false -> tmp
     end
   end
 
-  # Handles registration of `set_many()` command calls.
+  # Handles registration of `put_many()` command calls.
   #
-  # This is the same as the `set()` handler except that it
+  # This is the same as the `put()` handler except that it
   # will count the number of pairs being processed.
-  defp register_action(stats, { :set_many, [ pairs | _ ] }, { _status, value }) do
-    tmp = increment(stats, :set_many, value, 1)
+  defp register_action(stats, { :put_many, [ pairs | _ ] }, { _status, value }) do
+    tmp = increment(stats, :put_many, value, 1)
     case value do
       true  -> increment(tmp, :global, :setCount, length(pairs))
       false -> tmp

--- a/test/cachex/actions/clear_test.exs
+++ b/test/cachex/actions/clear_test.exs
@@ -12,9 +12,9 @@ defmodule Cachex.Actions.ClearTest do
     cache = Helper.create_cache([ hooks: [ hook ] ])
 
     # fill with some items
-    { :ok, true } = Cachex.set(cache, 1, 1)
-    { :ok, true } = Cachex.set(cache, 2, 2)
-    { :ok, true } = Cachex.set(cache, 3, 3)
+    { :ok, true } = Cachex.put(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 2, 2)
+    { :ok, true } = Cachex.put(cache, 3, 3)
 
     # clear all hook
     Helper.flush()

--- a/test/cachex/actions/count_test.exs
+++ b/test/cachex/actions/count_test.exs
@@ -11,14 +11,14 @@ defmodule Cachex.Actions.CountTest do
     cache = Helper.create_cache([ hooks: [ hook ] ])
 
     # fill with some items
-    { :ok, true } = Cachex.set(cache, 1, 1)
-    { :ok, true } = Cachex.set(cache, 2, 2)
-    { :ok, true } = Cachex.set(cache, 3, 3)
+    { :ok, true } = Cachex.put(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 2, 2)
+    { :ok, true } = Cachex.put(cache, 3, 3)
 
     # add some expired items
-    { :ok, true } = Cachex.set(cache, 4, 4, ttl: 1)
-    { :ok, true } = Cachex.set(cache, 5, 5, ttl: 1)
-    { :ok, true } = Cachex.set(cache, 6, 6, ttl: 1)
+    { :ok, true } = Cachex.put(cache, 4, 4, ttl: 1)
+    { :ok, true } = Cachex.put(cache, 5, 5, ttl: 1)
+    { :ok, true } = Cachex.put(cache, 6, 6, ttl: 1)
 
     # let entries expire
     :timer.sleep(2)

--- a/test/cachex/actions/decr_test.exs
+++ b/test/cachex/actions/decr_test.exs
@@ -50,7 +50,7 @@ defmodule Cachex.Actions.DecrTest do
     cache = Helper.create_cache()
 
     # set a non-numeric value
-    { :ok, true } = Cachex.set(cache, "key", "value")
+    { :ok, true } = Cachex.put(cache, "key", "value")
 
     # try to increment the value
     result = Cachex.decr(cache, "key", 1)

--- a/test/cachex/actions/del_test.exs
+++ b/test/cachex/actions/del_test.exs
@@ -12,7 +12,7 @@ defmodule Cachex.Actions.DelTest do
     cache = Helper.create_cache([ hooks: [ hook ] ])
 
     # add some cache entries
-    { :ok, true } = Cachex.set(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 1, 1)
 
     # delete some entries
     result1 = Cachex.del(cache, 1)

--- a/test/cachex/actions/dump_test.exs
+++ b/test/cachex/actions/dump_test.exs
@@ -13,7 +13,7 @@ defmodule Cachex.Actions.DumpTest do
     cache = Helper.create_cache()
 
     # add some cache entries
-    { :ok, true } = Cachex.set(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 1, 1)
 
     # create a local path to write to
     path = Path.join(tmp, Helper.gen_rand_bytes(8))

--- a/test/cachex/actions/empty_test.exs
+++ b/test/cachex/actions/empty_test.exs
@@ -22,7 +22,7 @@ defmodule Cachex.Actions.EmptyTest do
     assert_receive({ { :empty?, [[]] }, ^result1 })
 
     # add some cache entries
-    { :ok, true } = Cachex.set(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 1, 1)
 
     # check if the cache is empty
     result2 = Cachex.empty?(cache)

--- a/test/cachex/actions/execute_test.exs
+++ b/test/cachex/actions/execute_test.exs
@@ -11,9 +11,9 @@ defmodule Cachex.Actions.ExecuteTest do
     # start an execution block
     result = Cachex.execute(cache, fn(cache) ->
       [
-        Cachex.set!(cache, 1, 1),
-        Cachex.set!(cache, 2, 2),
-        Cachex.set!(cache, 3, 3)
+        Cachex.put!(cache, 1, 1),
+        Cachex.put!(cache, 2, 2),
+        Cachex.put!(cache, 3, 3)
       ]
     end)
 

--- a/test/cachex/actions/exists_test.exs
+++ b/test/cachex/actions/exists_test.exs
@@ -12,8 +12,8 @@ defmodule Cachex.Actions.ExistsTest do
     cache = Helper.create_cache([ hooks: [ hook ] ])
 
     # add some keys to the cache
-    { :ok, true } = Cachex.set(cache, 1, 1)
-    { :ok, true } = Cachex.set(cache, 2, 2, ttl: 1)
+    { :ok, true } = Cachex.put(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 2, 2, ttl: 1)
 
     # let TTLs clear
     :timer.sleep(2)

--- a/test/cachex/actions/expire_at_test.exs
+++ b/test/cachex/actions/expire_at_test.exs
@@ -13,9 +13,9 @@ defmodule Cachex.Actions.ExpireAtTest do
     cache = Helper.create_cache([ hooks: [ hook ] ])
 
     # add some keys to the cache
-    { :ok, true } = Cachex.set(cache, 1, 1)
-    { :ok, true } = Cachex.set(cache, 2, 2, ttl: 10)
-    { :ok, true } = Cachex.set(cache, 3, 3, ttl: 10)
+    { :ok, true } = Cachex.put(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 2, 2, ttl: 10)
+    { :ok, true } = Cachex.put(cache, 3, 3, ttl: 10)
 
     # clear messages
     Helper.flush()

--- a/test/cachex/actions/expire_test.exs
+++ b/test/cachex/actions/expire_test.exs
@@ -13,9 +13,9 @@ defmodule Cachex.Actions.ExpireTest do
     cache = Helper.create_cache([ hooks: [ hook ] ])
 
     # add some keys to the cache
-    { :ok, true } = Cachex.set(cache, 1, 1)
-    { :ok, true } = Cachex.set(cache, 2, 2, ttl: 10)
-    { :ok, true } = Cachex.set(cache, 3, 3, ttl: 10)
+    { :ok, true } = Cachex.put(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 2, 2, ttl: 10)
+    { :ok, true } = Cachex.put(cache, 3, 3, ttl: 10)
 
     # clear messages
     Helper.flush()

--- a/test/cachex/actions/fetch_test.exs
+++ b/test/cachex/actions/fetch_test.exs
@@ -20,8 +20,8 @@ defmodule Cachex.Actions.FetchTest do
     ])
 
     # set some keys in the cache
-    { :ok, true } = Cachex.set(cache1, "key1", 1)
-    { :ok, true } = Cachex.set(cache1, "key2", 2, ttl: 1)
+    { :ok, true } = Cachex.put(cache1, "key1", 1)
+    { :ok, true } = Cachex.put(cache1, "key2", 2, ttl: 1)
 
     # wait for the TTL to pass
     :timer.sleep(2)

--- a/test/cachex/actions/get_and_update_test.exs
+++ b/test/cachex/actions/get_and_update_test.exs
@@ -12,11 +12,11 @@ defmodule Cachex.Actions.GetAndUpdateTest do
     cache = Helper.create_cache([ hooks: [ hook ] ])
 
     # set some keys in the cache
-    { :ok, true } = Cachex.set(cache, 1, 1)
-    { :ok, true } = Cachex.set(cache, 2, 2, ttl: 1)
-    { :ok, true } = Cachex.set(cache, 4, 4, ttl: 1000)
-    { :ok, true } = Cachex.set(cache, 5, 5)
-    { :ok, true } = Cachex.set(cache, 6, 6)
+    { :ok, true } = Cachex.put(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 2, 2, ttl: 1)
+    { :ok, true } = Cachex.put(cache, 4, 4, ttl: 1000)
+    { :ok, true } = Cachex.put(cache, 5, 5)
+    { :ok, true } = Cachex.put(cache, 6, 6)
 
     # wait for the TTL to pass
     :timer.sleep(25)

--- a/test/cachex/actions/get_test.exs
+++ b/test/cachex/actions/get_test.exs
@@ -13,8 +13,8 @@ defmodule Cachex.Actions.GetTest do
     cache1 = Helper.create_cache([ hooks: [ hook ] ])
 
     # set some keys in the cache
-    { :ok, true } = Cachex.set(cache1, 1, 1)
-    { :ok, true } = Cachex.set(cache1, 2, 2, ttl: 1)
+    { :ok, true } = Cachex.put(cache1, 1, 1)
+    { :ok, true } = Cachex.put(cache1, 2, 2, ttl: 1)
 
     # wait for the TTL to pass
     :timer.sleep(2)

--- a/test/cachex/actions/incr_test.exs
+++ b/test/cachex/actions/incr_test.exs
@@ -50,7 +50,7 @@ defmodule Cachex.Actions.IncrTest do
     cache = Helper.create_cache()
 
     # set a non-numeric value
-    { :ok, true } = Cachex.set(cache, "key", "value")
+    { :ok, true } = Cachex.put(cache, "key", "value")
 
     # try to increment the value
     result = Cachex.incr(cache, "key")

--- a/test/cachex/actions/inspect_test.exs
+++ b/test/cachex/actions/inspect_test.exs
@@ -10,7 +10,7 @@ defmodule Cachex.Actions.InspectTest do
 
     # set several values in the cache
     for x <- 1..3 do
-      { :ok, true } = Cachex.set(cache, "key#{x}", "value#{x}", ttl: 1)
+      { :ok, true } = Cachex.put(cache, "key#{x}", "value#{x}", ttl: 1)
     end
 
     # make sure they expire
@@ -106,7 +106,7 @@ defmodule Cachex.Actions.InspectTest do
     ctime = now()
 
     # set a cache record
-    { :ok, true } = Cachex.set(cache, 1, "one", ttl: 1000)
+    { :ok, true } = Cachex.put(cache, 1, "one", ttl: 1000)
 
     # fetch some records
     record1 = Cachex.inspect(cache, { :entry, 1 })

--- a/test/cachex/actions/invoke_test.exs
+++ b/test/cachex/actions/invoke_test.exs
@@ -16,7 +16,7 @@ defmodule Cachex.Actions.InvokeTest do
     ])
 
     # set a list inside the cache
-    { :ok, true } = Cachex.set(cache, "list", [ 1, 2, 3, 4 ])
+    { :ok, true } = Cachex.put(cache, "list", [ 1, 2, 3, 4 ])
 
     # retrieve the raw record
     { :entry, "list", touched, nil, _val } = Cachex.inspect!(cache, { :entry, "list" })
@@ -62,7 +62,7 @@ defmodule Cachex.Actions.InvokeTest do
     # define a validation function
     validate = fn(list, expected) ->
       # set a list inside the cache
-      { :ok, true } = Cachex.set(cache, "list", list)
+      { :ok, true } = Cachex.put(cache, "list", list)
 
       # retrieve the last value
       last = Cachex.invoke(cache, "list", :last)

--- a/test/cachex/actions/keys_test.exs
+++ b/test/cachex/actions/keys_test.exs
@@ -13,14 +13,14 @@ defmodule Cachex.Actions.KeysTest do
     cache = Helper.create_cache([ hooks: [ hook ] ])
 
     # fill with some items
-    { :ok, true } = Cachex.set(cache, 1, 1)
-    { :ok, true } = Cachex.set(cache, 2, 2)
-    { :ok, true } = Cachex.set(cache, 3, 3)
+    { :ok, true } = Cachex.put(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 2, 2)
+    { :ok, true } = Cachex.put(cache, 3, 3)
 
     # add some expired items
-    { :ok, true } = Cachex.set(cache, 4, 4, ttl: 1)
-    { :ok, true } = Cachex.set(cache, 5, 5, ttl: 1)
-    { :ok, true } = Cachex.set(cache, 6, 6, ttl: 1)
+    { :ok, true } = Cachex.put(cache, 4, 4, ttl: 1)
+    { :ok, true } = Cachex.put(cache, 5, 5, ttl: 1)
+    { :ok, true } = Cachex.put(cache, 6, 6, ttl: 1)
 
     # let entries expire
     :timer.sleep(2)

--- a/test/cachex/actions/load_test.exs
+++ b/test/cachex/actions/load_test.exs
@@ -13,7 +13,7 @@ defmodule Cachex.Actions.LoadTest do
     cache = Helper.create_cache()
 
     # add some cache entries
-    { :ok, true } = Cachex.set(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 1, 1)
 
     # create a local path to write to
     path = Path.join(tmp, Helper.gen_rand_bytes(8))

--- a/test/cachex/actions/persist_test.exs
+++ b/test/cachex/actions/persist_test.exs
@@ -12,8 +12,8 @@ defmodule Cachex.Actions.PersistTest do
     cache = Helper.create_cache([ hooks: [ hook ] ])
 
     # add some keys to the cache
-    { :ok, true } = Cachex.set(cache, 1, 1)
-    { :ok, true } = Cachex.set(cache, 2, 2, ttl: 1000)
+    { :ok, true } = Cachex.put(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 2, 2, ttl: 1000)
 
     # clear messages
     Helper.flush()

--- a/test/cachex/actions/purge_test.exs
+++ b/test/cachex/actions/purge_test.exs
@@ -13,7 +13,7 @@ defmodule Cachex.Actions.PurgeTest do
     cache = Helper.create_cache([ hooks: [ hook ] ])
 
     # add a new cache entry
-    { :ok, true } = Cachex.set(cache, "key", "value", ttl: 25)
+    { :ok, true } = Cachex.put(cache, "key", "value", ttl: 25)
 
     # flush messages
     Helper.flush()

--- a/test/cachex/actions/put_many_test.exs
+++ b/test/cachex/actions/put_many_test.exs
@@ -1,4 +1,4 @@
-defmodule Cachex.Actions.SetManyTest do
+defmodule Cachex.Actions.PutManyTest do
   use CachexCase
 
   # This test verifies the addition of many new entries to a cache. It will
@@ -16,10 +16,10 @@ defmodule Cachex.Actions.SetManyTest do
     cache2 = Helper.create_cache([ hooks: [ hook ], expiration: expiration(default: 10000) ])
 
     # set some values in the cache
-    set1 = Cachex.set_many(cache1, [ { 1, 1 }, { 2, 2 } ])
-    set2 = Cachex.set_many(cache1, [ { 3, 3 }, { 4, 4 } ], ttl: 5000)
-    set3 = Cachex.set_many(cache2, [ { 1, 1 }, { 2, 2 } ])
-    set4 = Cachex.set_many(cache2, [ { 3, 3 }, { 4, 4 } ], ttl: 5000)
+    set1 = Cachex.put_many(cache1, [ { 1, 1 }, { 2, 2 } ])
+    set2 = Cachex.put_many(cache1, [ { 3, 3 }, { 4, 4 } ], ttl: 5000)
+    set3 = Cachex.put_many(cache2, [ { 1, 1 }, { 2, 2 } ])
+    set4 = Cachex.put_many(cache2, [ { 3, 3 }, { 4, 4 } ], ttl: 5000)
 
     # ensure all set actions worked
     assert(set1 == { :ok, true })
@@ -28,10 +28,10 @@ defmodule Cachex.Actions.SetManyTest do
     assert(set4 == { :ok, true })
 
     # verify the hooks were updated with the message
-    assert_receive({ { :set_many, [ [ { 1, 1 }, { 2, 2 } ], [] ] }, ^set1 })
-    assert_receive({ { :set_many, [ [ { 1, 1 }, { 2, 2 } ], [] ] }, ^set3 })
-    assert_receive({ { :set_many, [ [ { 3, 3 }, { 4, 4 } ], [ ttl: 5000 ] ] }, ^set2 })
-    assert_receive({ { :set_many, [ [ { 3, 3 }, { 4, 4 } ], [ ttl: 5000 ] ] }, ^set4 })
+    assert_receive({ { :put_many, [ [ { 1, 1 }, { 2, 2 } ], [] ] }, ^set1 })
+    assert_receive({ { :put_many, [ [ { 1, 1 }, { 2, 2 } ], [] ] }, ^set3 })
+    assert_receive({ { :put_many, [ [ { 3, 3 }, { 4, 4 } ], [ ttl: 5000 ] ] }, ^set2 })
+    assert_receive({ { :put_many, [ [ { 3, 3 }, { 4, 4 } ], [ ttl: 5000 ] ] }, ^set4 })
 
     # read back all values from the cache
     value1 = Cachex.get(cache1, 1)
@@ -87,7 +87,7 @@ defmodule Cachex.Actions.SetManyTest do
     cache = Helper.create_cache()
 
     # try set some values in the cache
-    result = Cachex.set_many(cache, [])
+    result = Cachex.put_many(cache, [])
 
     # should work, but no writes
     assert(result == { :ok, false })
@@ -104,8 +104,8 @@ defmodule Cachex.Actions.SetManyTest do
     cache = Helper.create_cache([ hooks: [ hook ] ])
 
     # try set some values in the cache
-    set1 = Cachex.set_many(cache, [ { 1, 1 }, "key" ])
-    set2 = Cachex.set_many(cache, [ { 1, 1 }, { 2, 2, 2} ])
+    set1 = Cachex.put_many(cache, [ { 1, 1 }, "key" ])
+    set2 = Cachex.put_many(cache, [ { 1, 1 }, { 2, 2, 2} ])
 
     # ensure all set actions failed
     assert(set1 == error(:invalid_pairs))
@@ -113,7 +113,7 @@ defmodule Cachex.Actions.SetManyTest do
 
     # try without a list of pairs
     assert_raise(FunctionClauseError, fn ->
-      Cachex.set_many(cache, { 1, 1 })
+      Cachex.put_many(cache, { 1, 1 })
     end)
   end
 end

--- a/test/cachex/actions/put_test.exs
+++ b/test/cachex/actions/put_test.exs
@@ -1,4 +1,4 @@
-defmodule Cachex.Actions.SetTest do
+defmodule Cachex.Actions.PutTest do
   use CachexCase
 
   # This test verifies the addition of new entries to the cache. We ensure that
@@ -16,10 +16,10 @@ defmodule Cachex.Actions.SetTest do
     cache2 = Helper.create_cache([ hooks: [ hook ], expiration: expiration(default: 10000) ])
 
     # set some values in the cache
-    set1 = Cachex.set(cache1, 1, 1)
-    set2 = Cachex.set(cache1, 2, 2, ttl: 5000)
-    set3 = Cachex.set(cache2, 1, 1)
-    set4 = Cachex.set(cache2, 2, 2, ttl: 5000)
+    set1 = Cachex.put(cache1, 1, 1)
+    set2 = Cachex.put(cache1, 2, 2, ttl: 5000)
+    set3 = Cachex.put(cache2, 1, 1)
+    set4 = Cachex.put(cache2, 2, 2, ttl: 5000)
 
     # ensure all set actions worked
     assert(set1 == { :ok, true })
@@ -28,10 +28,10 @@ defmodule Cachex.Actions.SetTest do
     assert(set4 == { :ok, true })
 
     # verify the hooks were updated with the message
-    assert_receive({ { :set, [ 1, 1, [] ] }, ^set1 })
-    assert_receive({ { :set, [ 1, 1, [] ] }, ^set3 })
-    assert_receive({ { :set, [ 2, 2, [ ttl: 5000 ] ] }, ^set2 })
-    assert_receive({ { :set, [ 2, 2, [ ttl: 5000 ] ] }, ^set4 })
+    assert_receive({ { :put, [ 1, 1, [] ] }, ^set1 })
+    assert_receive({ { :put, [ 1, 1, [] ] }, ^set3 })
+    assert_receive({ { :put, [ 2, 2, [ ttl: 5000 ] ] }, ^set2 })
+    assert_receive({ { :put, [ 2, 2, [ ttl: 5000 ] ] }, ^set4 })
 
     # read back all values from the cache
     value1 = Cachex.get(cache1, 1)

--- a/test/cachex/actions/refresh_test.exs
+++ b/test/cachex/actions/refresh_test.exs
@@ -13,8 +13,8 @@ defmodule Cachex.Actions.RefreshTest do
     cache = Helper.create_cache([ hooks: [ hook ] ])
 
     # add some keys to the cache
-    { :ok, true } = Cachex.set(cache, 1, 1)
-    { :ok, true } = Cachex.set(cache, 2, 2, ttl: 1000)
+    { :ok, true } = Cachex.put(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 2, 2, ttl: 1000)
 
     # clear messages
     Helper.flush()

--- a/test/cachex/actions/reset_test.exs
+++ b/test/cachex/actions/reset_test.exs
@@ -20,8 +20,8 @@ defmodule Cachex.Actions.ResetTest do
     ctime1 = now()
 
     # set some values
-    { :ok, true } = Cachex.set(cache1, 1, 1)
-    { :ok, true } = Cachex.set(cache2, 1, 1)
+    { :ok, true } = Cachex.put(cache1, 1, 1)
+    { :ok, true } = Cachex.put(cache2, 1, 1)
 
     # retrieve the stats
     stats1 = Cachex.stats!(cache1)
@@ -70,7 +70,7 @@ defmodule Cachex.Actions.ResetTest do
     ctime1 = now()
 
     # set some values
-    { :ok, true } = Cachex.set(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 1, 1)
 
     # retrieve the stats
     stats1 = Cachex.stats!(cache)
@@ -111,7 +111,7 @@ defmodule Cachex.Actions.ResetTest do
     ctime1 = now()
 
     # set some values
-    { :ok, true } = Cachex.set(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 1, 1)
 
     # retrieve the stats
     stats1 = Cachex.stats!(cache)

--- a/test/cachex/actions/set_many_test.exs
+++ b/test/cachex/actions/set_many_test.exs
@@ -1,0 +1,39 @@
+defmodule Cachex.Actions.SetManyTest do
+  use CachexCase
+
+  # This test just covers the case of forwarding calls
+  # to set_many() through to put_many() in order to
+  # validate the backwards compatibility calls.
+  test "forwarding calls to put_many(2/3)" do
+    # create a test cache
+    cache = Helper.create_cache()
+
+    # set values in the cache
+    result1 = Cachex.set_many(cache, [ { 1, 1 }, { 2, 2 } ])
+    result2 = Cachex.set_many(cache, [ { 3, 3 }, { 4, 4 } ], [ ttl: 5000 ])
+
+    # verify the results of the writes
+    assert(result1 == { :ok, true })
+    assert(result2 == { :ok, true })
+
+    # retrieve the written value
+    result2 = Cachex.get(cache, 1)
+    result3 = Cachex.get(cache, 2)
+    result4 = Cachex.get(cache, 3)
+    result5 = Cachex.get(cache, 4)
+
+    # check that it was written
+    assert(result2 == { :ok, 1 })
+    assert(result3 == { :ok, 2 })
+    assert(result4 == { :ok, 3 })
+    assert(result5 == { :ok, 4 })
+
+    # check the ttl on the last calls
+    result6 = Cachex.ttl!(cache, 3)
+    result7 = Cachex.ttl!(cache, 4)
+
+    # the second should have a TTL around 5s
+    assert_in_delta(result6, 5000, 10)
+    assert_in_delta(result7, 5000, 10)
+  end
+end

--- a/test/cachex/actions/set_test.exs
+++ b/test/cachex/actions/set_test.exs
@@ -1,0 +1,33 @@
+defmodule Cachex.Actions.SetTest do
+  use CachexCase
+
+  # This test just covers the case of forwarding calls
+  # to set() through to put() in order to validate the
+  # backwards compatibility of the deprecated calls.
+  test "forwarding calls to put(3/4)" do
+    # create a test cache
+    cache = Helper.create_cache()
+
+    # set values in the cache
+    result1 = Cachex.set(cache, 1, 1)
+    result2 = Cachex.set(cache, 2, 2, [ ttl: 5000 ])
+
+    # verify the results of the writes
+    assert(result1 == { :ok, true })
+    assert(result2 == { :ok, true })
+
+    # retrieve the written value
+    result2 = Cachex.get(cache, 1)
+    result3 = Cachex.get(cache, 2)
+
+    # check that it was written
+    assert(result2 == { :ok, 1 })
+    assert(result3 == { :ok, 2 })
+
+    # check the ttl on the second call
+    result4 = Cachex.ttl!(cache, 2)
+
+    # the second should have a TTL around 5s
+    assert_in_delta(result4, 5000, 10)
+  end
+end

--- a/test/cachex/actions/size_test.exs
+++ b/test/cachex/actions/size_test.exs
@@ -22,7 +22,7 @@ defmodule Cachex.Actions.SizeTest do
     assert_receive({ { :size, [[]] }, ^result1 })
 
     # add some cache entries
-    { :ok, true } = Cachex.set(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 1, 1)
 
     # retrieve the cache size
     result2 = Cachex.size(cache)
@@ -34,7 +34,7 @@ defmodule Cachex.Actions.SizeTest do
     assert_receive({ { :size, [[]] }, ^result2 })
 
     # add a final entry
-    { :ok, true } = Cachex.set(cache, 2, 2, ttl: 1)
+    { :ok, true } = Cachex.put(cache, 2, 2, ttl: 1)
 
     # let it expire
     :timer.sleep(2)

--- a/test/cachex/actions/stats_test.exs
+++ b/test/cachex/actions/stats_test.exs
@@ -104,11 +104,11 @@ defmodule Cachex.Actions.StatsTest do
     { :missing, nil } = Cachex.get(cache1, 1)
 
     # set cache2 to 100% hits
-    { :ok, true } = Cachex.set(cache2, 1, 1)
+    { :ok, true } = Cachex.put(cache2, 1, 1)
     { :ok,    1 } = Cachex.get(cache2, 1)
 
     # set cache3 to be 50% each way
-    { :ok, true } = Cachex.set(cache3, 1, 1)
+    { :ok, true } = Cachex.put(cache3, 1, 1)
     { :ok,    1 } = Cachex.get(cache3, 1)
     { :missing, nil } = Cachex.get(cache3, 2)
 

--- a/test/cachex/actions/stats_test.exs
+++ b/test/cachex/actions/stats_test.exs
@@ -12,7 +12,7 @@ defmodule Cachex.Actions.StatsTest do
     ctime = now()
 
     # execute some cache actions
-    { :ok, true } = Cachex.set(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 1, 1)
     { :ok,    1 } = Cachex.get(cache, 1)
 
     # retrieve default stats
@@ -22,7 +22,7 @@ defmodule Cachex.Actions.StatsTest do
     stats2 = Cachex.stats!(cache, [ for: [ :global, :get ] ])
 
     # retrieve specific stats
-    stats3 = Cachex.stats!(cache, [ for: [ :get, :set ] ])
+    stats3 = Cachex.stats!(cache, [ for: [ :get, :put ] ])
 
     # retrieve raw stats
     stats4 = Cachex.stats!(cache, [ for: :raw ])
@@ -52,7 +52,7 @@ defmodule Cachex.Actions.StatsTest do
       get: %{
         ok: 1
       },
-      set: %{
+      put: %{
         true: 1
       }
     })
@@ -65,7 +65,7 @@ defmodule Cachex.Actions.StatsTest do
       opCount: 2,
       setCount: 1
     })
-    assert(stats4.set == %{ true: 1 })
+    assert(stats4.put == %{ true: 1 })
   end
 
   # This test just verifies that we receive an error trying to retrieve stats

--- a/test/cachex/actions/stream_test.exs
+++ b/test/cachex/actions/stream_test.exs
@@ -9,9 +9,9 @@ defmodule Cachex.Actions.StreamTest do
     cache = Helper.create_cache()
 
     # add some keys to the cache
-    { :ok, true } = Cachex.set(cache, "key1", "value1")
-    { :ok, true } = Cachex.set(cache, "key2", "value2")
-    { :ok, true } = Cachex.set(cache, "key3", "value3")
+    { :ok, true } = Cachex.put(cache, "key1", "value1")
+    { :ok, true } = Cachex.put(cache, "key2", "value2")
+    { :ok, true } = Cachex.put(cache, "key3", "value3")
 
     # create a cache stream
     { :ok, stream } = Cachex.stream(cache)
@@ -35,9 +35,9 @@ defmodule Cachex.Actions.StreamTest do
     cache = Helper.create_cache()
 
     # add some keys to the cache
-    { :ok, true } = Cachex.set(cache, "key1", "value1")
-    { :ok, true } = Cachex.set(cache, "key2", "value2")
-    { :ok, true } = Cachex.set(cache, "key3", "value3")
+    { :ok, true } = Cachex.put(cache, "key1", "value1")
+    { :ok, true } = Cachex.put(cache, "key2", "value2")
+    { :ok, true } = Cachex.put(cache, "key3", "value3")
 
     # create cache streams
     { :ok, stream1 } = Cachex.stream(cache, [ of: { { :key, :value, :key, :ttl } } ])

--- a/test/cachex/actions/take_test.exs
+++ b/test/cachex/actions/take_test.exs
@@ -12,8 +12,8 @@ defmodule Cachex.Actions.TakeTest do
     cache = Helper.create_cache([ hooks: [ hook ] ])
 
     # set some keys in the cache
-    { :ok, true } = Cachex.set(cache, 1, 1)
-    { :ok, true } = Cachex.set(cache, 2, 2, ttl: 1)
+    { :ok, true } = Cachex.put(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 2, 2, ttl: 1)
 
     # wait for the TTL to pass
     :timer.sleep(2)

--- a/test/cachex/actions/touch_test.exs
+++ b/test/cachex/actions/touch_test.exs
@@ -16,8 +16,8 @@ defmodule Cachex.Actions.TouchTest do
     state = Services.Overseer.retrieve(cache)
 
     # add some keys to the cache
-    { :ok, true } = Cachex.set(cache, 1, 1)
-    { :ok, true } = Cachex.set(cache, 2, 2, ttl: 1000)
+    { :ok, true } = Cachex.put(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 2, 2, ttl: 1000)
 
     # clear messages
     Helper.flush()

--- a/test/cachex/actions/ttl_test.exs
+++ b/test/cachex/actions/ttl_test.exs
@@ -9,8 +9,8 @@ defmodule Cachex.Actions.TtlTest do
     cache = Helper.create_cache()
 
     # set several keys in the cache
-    { :ok, true } = Cachex.set(cache, 1, 1)
-    { :ok, true } = Cachex.set(cache, 2, 2, ttl: 10000)
+    { :ok, true } = Cachex.put(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 2, 2, ttl: 10000)
 
     # verify the TTL of both keys
     ttl1 = Cachex.ttl(cache, 1)

--- a/test/cachex/actions/update_test.exs
+++ b/test/cachex/actions/update_test.exs
@@ -10,10 +10,10 @@ defmodule Cachex.Actions.UpdateTest do
     cache = Helper.create_cache()
 
     # set a value with no TTL inside the cache
-    { :ok, true } = Cachex.set(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 1, 1)
 
     # set a value with a TTL in the cache
-    { :ok, true } = Cachex.set(cache, 2, 2, ttl: 10000)
+    { :ok, true } = Cachex.put(cache, 2, 2, ttl: 10000)
 
     # attempt to update both keys
     update1 = Cachex.update(cache, 1, 3)

--- a/test/cachex/actions_test.exs
+++ b/test/cachex/actions_test.exs
@@ -177,8 +177,8 @@ defmodule Cachex.ActionsTest do
     result3 = Cachex.Actions.write_mod(:unknown)
 
     # the first two should be Set actions
-    assert(result1 == Cachex.Actions.Set)
-    assert(result2 == Cachex.Actions.Set)
+    assert(result1 == Cachex.Actions.Put)
+    assert(result2 == Cachex.Actions.Put)
 
     # the third should be an Update
     assert(result3 == Cachex.Actions.Update)

--- a/test/cachex/actions_test.exs
+++ b/test/cachex/actions_test.exs
@@ -15,8 +15,8 @@ defmodule Cachex.ActionsTest do
     state = Services.Overseer.retrieve(cache)
 
     # write several values
-    { :ok, true } = Cachex.set(cache, 1, 1)
-    { :ok, true } = Cachex.set(cache, 2, 2, ttl: 1)
+    { :ok, true } = Cachex.put(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 2, 2, ttl: 1)
 
     # let the TTL expire
     :timer.sleep(2)

--- a/test/cachex/policy/lrw_test.exs
+++ b/test/cachex/policy/lrw_test.exs
@@ -13,7 +13,7 @@ defmodule Cachex.Policy.LRWTest do
 
     # add 5000 keys to the cache
     for x <- 1..5000 do
-      { :ok, true } = Cachex.set(state, x, x)
+      { :ok, true } = Cachex.put(state, x, x)
     end
 
     # retrieve the cache size
@@ -49,7 +49,7 @@ defmodule Cachex.Policy.LRWTest do
     # add 1000 keys to the cache
     for x <- 1..100 do
       # add the entry to the cache
-      { :ok, true } = Cachex.set(state, x, x)
+      { :ok, true } = Cachex.put(state, x, x)
 
       # tick to make sure each has a new touch time
       :timer.sleep(1)
@@ -65,7 +65,7 @@ defmodule Cachex.Policy.LRWTest do
     Helper.flush()
 
     # add a new key to the cache to trigger evictions
-    { :ok, true } = Cachex.set(state, 101, 101)
+    { :ok, true } = Cachex.put(state, 101, 101)
 
     # verify the cache shrinks to 25%
     Helper.poll(250, 25, fn ->
@@ -117,7 +117,7 @@ defmodule Cachex.Policy.LRWTest do
     # set 50 keys without ttl
     for x <- 1..50 do
       # set the key
-      { :ok, true } = Cachex.set(state, x, x)
+      { :ok, true } = Cachex.put(state, x, x)
 
       # tick to make sure each has a new touch time
       :timer.sleep(1)
@@ -126,7 +126,7 @@ defmodule Cachex.Policy.LRWTest do
     # set a more recent 50 keys
     for x <- 51..100 do
       # set the key
-      { :ok, true } = Cachex.set(state, x, x, ttl: 1)
+      { :ok, true } = Cachex.put(state, x, x, ttl: 1)
 
       # tick to make sure each has a new touch time
       :timer.sleep(1)
@@ -139,7 +139,7 @@ defmodule Cachex.Policy.LRWTest do
     assert(size1 == 100)
 
     # add a new key to the cache to trigger evictions
-    { :ok, true } = Cachex.set(state, 101, 101)
+    { :ok, true } = Cachex.put(state, 101, 101)
 
     # verify the cache shrinks to 51%
     Helper.poll(250, 51, fn ->

--- a/test/cachex/services/janitor_test.exs
+++ b/test/cachex/services/janitor_test.exs
@@ -59,7 +59,7 @@ defmodule Cachex.Services.JanitorTest do
     cache = Services.Overseer.retrieve(cache)
 
     # add a new cache entry
-    { :ok, true } = Cachex.set(cache, "key", "value", ttl: ttl_value)
+    { :ok, true } = Cachex.put(cache, "key", "value", ttl: ttl_value)
 
     # check that the key exists
     exists1 = Cachex.exists?(cache, "key")

--- a/test/cachex/stats_test.exs
+++ b/test/cachex/stats_test.exs
@@ -415,7 +415,7 @@ defmodule Cachex.StatsTest do
     ctime = now()
 
     # carry out some cache operations
-    { :ok, true } = Cachex.set(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 1, 1)
     { :ok,    1 } = Cachex.get(cache, 1)
 
     # attempt to retrieve the cache stats

--- a/test/cachex/stats_test.exs
+++ b/test/cachex/stats_test.exs
@@ -190,7 +190,7 @@ defmodule Cachex.StatsTest do
   # This test ensures that a successful write will increment the setCount in the
   # global namespace, but otherwise only the false key is incremented inside the
   # set namespace, in order to avoid false positives.
-  test "registering set actions" do
+  test "registering put actions" do
     # create our base stats
     stats = %{ }
 
@@ -199,14 +199,14 @@ defmodule Cachex.StatsTest do
     payload2 = { :ok, false }
 
     # register the first payload
-    { :ok, results1 } = Cachex.Stats.handle_notify({ :set, [] }, payload1, stats)
+    { :ok, results1 } = Cachex.Stats.handle_notify({ :put, [] }, payload1, stats)
 
     # register the second payload
-    { :ok, results2 } = Cachex.Stats.handle_notify({ :set, [] }, payload2, results1)
+    { :ok, results2 } = Cachex.Stats.handle_notify({ :put, [] }, payload2, results1)
 
     # verify the combined results
     assert(results2 == %{
-      set: %{
+      put: %{
         true: 1,
         false: 1
       },
@@ -219,7 +219,7 @@ defmodule Cachex.StatsTest do
 
   # This operates in the same way as the test cases above, but verifies that
   # writing a batch will correctly count using the length of the batch itself.
-  test "registering set_many actions" do
+  test "registering put_many actions" do
     # create our base stats
     stats = %{ }
 
@@ -232,14 +232,14 @@ defmodule Cachex.StatsTest do
     batch2 = [ { "key", "value" }, { "yek", "eulav" } ]
 
     # register the first payload
-    { :ok, results1 } = Cachex.Stats.handle_notify({ :set_many, [ batch1 ] }, payload1, stats)
+    { :ok, results1 } = Cachex.Stats.handle_notify({ :put_many, [ batch1 ] }, payload1, stats)
 
     # register the second payload
-    { :ok, results2 } = Cachex.Stats.handle_notify({ :set_many, [ batch2 ] }, payload2, results1)
+    { :ok, results2 } = Cachex.Stats.handle_notify({ :put_many, [ batch2 ] }, payload2, results1)
 
     # verify the combined results
     assert(results2 == %{
-      set_many: %{
+      put_many: %{
         true: 1,
         false: 1
       },
@@ -425,6 +425,6 @@ defmodule Cachex.StatsTest do
     assert_in_delta(stats.meta.creationDate, ctime, 5)
     assert(stats.get == %{ ok: 1 })
     assert(stats.global == %{ hitCount: 1, opCount: 2, setCount: 1 })
-    assert(stats.set == %{ true: 1 })
+    assert(stats.put == %{ true: 1 })
   end
 end

--- a/test/cachex_test.exs
+++ b/test/cachex_test.exs
@@ -177,7 +177,7 @@ defmodule CachexTest do
     assert(is_even(length(definitions)))
 
     # verify the size to cause errors on addition/removal
-    assert(length(definitions) == 132)
+    assert(length(definitions) == 140)
 
     # validate all definitions
     for { name, arity } <- definitions do


### PR DESCRIPTION
This fixes #160.

All calls to `set/4` or `set_many/3` are now `put/4` or `put_many/3`. The old `set` and `set_many` signatures are left around for backwards compatibility, because I'm a nice guy. They're just delegates which are deliberately hidden from the documentation. It could be that we want to add them to the docs to discuss deprecation... but I can do that later. 

No plans on actually removing the delegates at this point; they're very little code noise so it is what it is.