### PR TITLE
Introduce cache warming functionality

### DIFF
--- a/lib/cachex/errors.ex
+++ b/lib/cachex/errors.ex
@@ -12,11 +12,14 @@ defmodule Cachex.Errors do
   than bloating blocks with potentially large error messages.
   """
   @known_errors [
-    :invalid_command,  :invalid_expiration, :invalid_fallback,
-    :invalid_hook,     :invalid_limit,      :invalid_match,
-    :invalid_name,     :invalid_option,     :invalid_pairs,
-    :janitor_disabled, :no_cache,           :non_numeric_value,
-    :not_started,      :stats_disabled,     :unreachable_file
+    :invalid_command,   :invalid_expiration,
+    :invalid_fallback,  :invalid_hook,
+    :invalid_limit,     :invalid_match,
+    :invalid_name,      :invalid_option,
+    :invalid_pairs,     :invalid_warmer,
+    :janitor_disabled,  :no_cache,
+    :non_numeric_value, :not_started,
+    :stats_disabled,    :unreachable_file
   ]
 
   ##########
@@ -73,6 +76,8 @@ defmodule Cachex.Errors do
     do: "Invalid option syntax provided"
   def long_form(:invalid_pairs),
     do: "Invalid insertion pairs provided"
+  def long_form(:invalid_warmer),
+    do: "Invalid warmer definition provided"
   def long_form(:janitor_disabled),
     do: "Specified janitor process running"
   def long_form(:no_cache),

--- a/lib/cachex/services.ex
+++ b/lib/cachex/services.ex
@@ -49,6 +49,7 @@ defmodule Cachex.Services do
     |> Enum.concat(table_spec(cache))
     |> Enum.concat(locksmith_spec(cache))
     |> Enum.concat(informant_spec(cache))
+    |> Enum.concat(incubator_spec(cache))
     |> Enum.concat(courier_spec(cache))
     |> Enum.concat(janitor_spec(cache))
     |> Enum.concat(limit_spec(cache))
@@ -65,6 +66,14 @@ defmodule Cachex.Services do
   # by default as fallbacks are enabled by default (not behind a flag).
   defp courier_spec(cache() = cache),
     do: [ worker(Services.Courier, [ cache ]) ]
+
+  # Creates a specification for the Incubator supervisor.
+  #
+  # The incubator is essentially a supervisor around all warmers in assigned
+  # to a cache so they're managed correctly. If no warmers are associated to
+  # the cache, this supervisor will essentially no-op at startup.
+  defp incubator_spec(cache() = cache),
+    do: [ supervisor(Services.Incubator, [ cache ]) ]
 
   # Creates a specification for the Informant supervisor.
   #

--- a/lib/cachex/services/incubator.ex
+++ b/lib/cachex/services/incubator.ex
@@ -1,0 +1,38 @@
+defmodule Cachex.Services.Incubator do
+  @moduledoc """
+  Parent module for all warmer definitions for a cache.
+
+  The Incubator will control the supervision tree for all warmers that
+  are associated with a cache. This is very minimal supervision, with
+  no linking back except via the `Supervisor` access functions.
+  """
+  import Cachex.Spec
+
+  ##############
+  # Public API #
+  ##############
+
+  @doc """
+  Starts a new incubation service for a cache.
+
+  This will start a Supervisor to hold all warmer processes as defined in
+  the provided cache record. If no warmers are attached in the cache record,
+  this will skip creation to avoid unnecessary processes running.
+  """
+  @spec start_link(Spec.cache) :: Supervisor.on_start
+  def start_link(cache(warmers: [])),
+    do: :ignore
+  def start_link(cache(warmers: warmers) = cache) do
+    warmers
+    |> Enum.map(&spec(&1, cache))
+    |> Supervisor.start_link(strategy: :one_for_one)
+  end
+
+  ###############
+  # Private API #
+  ###############
+
+  # Generates a Supervisor specification for a hook.
+  defp spec(warmer(module: module, state: state), cache),
+    do: Supervisor.Spec.worker(GenServer, [ module, { cache, state } ], [ id: module ])
+end

--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -31,7 +31,8 @@ defmodule Cachex.Spec do
     fallback: fallback,
     hooks: hooks,
     limit: limit,
-    transactional: boolean
+    transactional: boolean,
+    warmers: [ warmer ]
   )
 
   # Record specification for a command instance
@@ -82,6 +83,12 @@ defmodule Cachex.Spec do
     options: Keyword.t
   )
 
+  # Record specification for a cache warmer
+  @type warmer :: record(:warmer,
+    module: atom,
+    state: any
+  )
+
   ###########
   # Records #
   ###########
@@ -100,7 +107,8 @@ defmodule Cachex.Spec do
     fallback: nil,
     hooks: nil,
     limit: nil,
-    transactional: false
+    transactional: false,
+    warmers: []
 
   @doc """
   Creates a command record from the provided values.
@@ -219,6 +227,19 @@ defmodule Cachex.Spec do
     reclaim: 0.1,
     options: []
 
+  @doc """
+  Creates a warmer record from the provided values.
+
+  A warmer record represents cache warmer processes to be run to populate keys.
+
+  A warmer should have a valid module provided, which correctly implements the behaviour
+  associated with `Cachex.Warmer`. A state can also be provided, which will be passed
+  to the execution callback of the provided module (which defaults to `nil`).
+  """
+  defrecord :warmer,
+    module: nil,
+    state: nil
+
   ###############
   # Record Docs #
   ###############
@@ -270,6 +291,12 @@ defmodule Cachex.Spec do
   """
   @spec limit(limit, Keyword.t) :: limit
   defmacro limit(record, args)
+
+  @doc """
+  Updates a warmer record from the provided values.
+  """
+  @spec warmer(warmer, Keyword.t) :: warmer
+  defmacro warmer(record, args)
 
   #############
   # Constants #

--- a/lib/cachex/warmer.ex
+++ b/lib/cachex/warmer.ex
@@ -1,0 +1,105 @@
+defmodule Cachex.Warmer do
+  @moduledoc """
+  Module controlling cache warmer behaviour definitions.
+
+  This module defines the cache warming implementation for Cachex, allowing the
+  user to register warmers against a cache to populate the tables on an interval.
+  Doing this allows for easy pulling against expensive values (such as those from
+  a backing database or remote server), without risking heavy usage.
+
+  Warmers are fired on a schedule, and are exposed via a very simple behaviour of
+  just an interval and a block to execute on the interval. It should be noted that
+  this is a moving interval, and it resets after execution has completed.
+  """
+
+  #############
+  # Behaviour #
+  #############
+
+  @doc """
+  Returns the interval this warmer will execute on.
+
+  This must be an integer representing a count of milliseconds to wait before
+  the next execution of the warmer. Anything else will cause either invalidation
+  errors on cache startup, or crashes at runtime.
+  """
+  @callback interval :: integer
+
+  @doc """
+  Executes actions to warm a cache instance on interval.
+
+  This can either return values to set in the cache, or the atom `:ignore` to
+  signal that there's nothing to be set at this point in time. Values to be set
+  should be returned as `{ :ok, pairs }` where pairs is a list of `{ key, value }`
+  pairs to place into the cache via `Cachex.put_many/3`.
+
+  If you wish to provide expiration against the keys, you can return a Tuple in
+  the form `{ :ok, pairs, opts }` where `opts` is a list of options as accepted
+  by the `Cachex.put_many/3` function, thus allowing you to expire your warmed
+  data. Unless this is provided, there is no explicit expiration associated with
+  warmed values (as predicting the appropriate expiration is not possible).
+
+  The argument provided here is the one provided as state to the warmer records
+  at cache configuration time; it will be `nil` if none was provided.
+  """
+  @callback execute(state :: any) :: :ignore
+    | { :ok, pairs :: [ { key :: any, value :: any } ] }
+    | { :ok, pairs :: [ { key :: any, value :: any } ], options :: Keyword.t }
+
+  ##################
+  # Implementation #
+  ##################
+
+  @doc false
+  defmacro __using__(_) do
+    quote location: :keep do
+      use GenServer
+
+      # enforce the behaviour
+      @behaviour Cachex.Warmer
+
+      @doc false
+      # Initializes the warmer from a provided state.
+      #
+      # Initialization will trigger an initial cache warming, and store
+      # the provided state for later to provide during further warming.
+      def init(state),
+        do: { send(self(), :cachex_warmer) && :ok, state }
+
+      @doc false
+      # Warms a number of keys in a cache.
+      #
+      # This is done by calling the `execute/1` callback with the state
+      # stored in the main process state. The results are placed into the
+      # cache via `Cachex.put_many/3` if returns in a Tuple tagged with the
+      # `:ok` atom. If `:ignore` is returned, nothing happens aside from
+      # scheduling the next execution of the warming to occur on interval.
+      def handle_info(:cachex_warmer, { cache, state } = process_state) do
+        try do
+          # execute, passing state
+          case execute(state) do
+            # no changes
+            :ignore ->
+              :ignore
+
+            # set pairs without options
+            { :ok, pairs } ->
+              Cachex.put_many(cache, pairs)
+
+            # set pairs with options
+            { :ok, pairs, options } ->
+              Cachex.put_many(cache, pairs, options)
+          end
+        rescue
+          _ -> nil
+        end
+
+        # trigger the warming to happen again after the interval
+        :erlang.send_after(interval(), self(), :cachex_warmer)
+
+        # no reply, and the state persist
+        { :noreply, process_state }
+      end
+    end
+  end
+end

--- a/test/cachex/errors_test.exs
+++ b/test/cachex/errors_test.exs
@@ -15,6 +15,7 @@ defmodule Cachex.ErrorsTest do
       invalid_name:       "Invalid cache name provided",
       invalid_option:     "Invalid option syntax provided",
       invalid_pairs:      "Invalid insertion pairs provided",
+      invalid_warmer:     "Invalid warmer definition provided",
       janitor_disabled:   "Specified janitor process running",
       no_cache:           "Specified cache not running",
       non_numeric_value:  "Attempted arithmetic operations on a non-numeric value",

--- a/test/cachex/services_test.exs
+++ b/test/cachex/services_test.exs
@@ -18,6 +18,7 @@ defmodule Cachex.ServicesTest do
       { Eternal, _, _, _, _, _ },
       { Services.Locksmith.Queue, _, _, _, _, _ },
       { Services.Informant, _, _, _, _, _ },
+      { Services.Incubator, _, _, _, _, _ },
       { Services.Courier, _, _, _, _, _ },
       { Services.Janitor, _, _, _, _, _ }
     ] = Services.cache_spec(cache)
@@ -33,6 +34,7 @@ defmodule Cachex.ServicesTest do
       { Eternal, _, _, _, _, _ },
       { Services.Locksmith.Queue, _, _, _, _, _ },
       { Services.Informant, _, _, _, _, _ },
+      { Services.Incubator, _, _, _, _, _ },
       { Services.Courier, _, _, _, _, _ },
       { Services.Janitor, _, _, _, _, _ },
       { Supervisor, { Supervisor, _, [ [ { __MODULE__.TestPolicy, _, _, _, _, _ } ], _ ] }, _, _, _, _ }
@@ -49,6 +51,7 @@ defmodule Cachex.ServicesTest do
       { Eternal, _, _, _, _, _ },
       { Services.Locksmith.Queue, _, _, _, _, _ },
       { Services.Informant, _, _, _, _, _ },
+      { Services.Incubator, _, _, _, _, _ },
       { Services.Courier, _, _, _, _, _ },
     ] = Services.cache_spec(cache)
   end

--- a/test/cachex/spec/validator_test.exs
+++ b/test/cachex/spec/validator_test.exs
@@ -204,4 +204,23 @@ defmodule Cachex.Spec.ValidatorTest do
     refute Validator.valid?(:limit, limit7)
     refute Validator.valid?(:limit, limit8)
   end
+
+  test "validation of warmer records" do
+    # create a warmer for validation
+    Helper.create_warmer(:validator_warmer, 1000, fn(_) ->
+      :ignore
+    end)
+
+    # define some records
+    warmer1 = warmer(module: :validator_warmer)
+    warmer2 = warmer(module: __MODULE__)
+    warmer3 = warmer(module: :missing)
+
+    # ensure the first is valid
+    assert Validator.valid?(:warmer, warmer1)
+
+    # the others are all invalid
+    refute Validator.valid?(:warmer, warmer2)
+    refute Validator.valid?(:warmer, warmer3)
+  end
 end

--- a/test/cachex/warmer_test.exs
+++ b/test/cachex/warmer_test.exs
@@ -1,0 +1,82 @@
+defmodule Cachex.WarmerTest do
+  use CachexCase
+
+  test "warmers which set basic values" do
+    # create a test warmer to pass to the cache
+    Helper.create_warmer(:basic_warmer, 50, fn(_) ->
+      { :ok, [ { 1, 1 } ] }
+    end)
+
+    # create a cache instance with a warmer
+    cache = Helper.create_cache([
+      warmers: [ warmer(module: :basic_warmer) ]
+    ])
+
+    # wait a while for it to fire
+    :timer.sleep(100)
+
+    # check that the key was warmed
+    assert Cachex.get!(cache, 1) == 1
+  end
+
+  test "warmers which set values with options" do
+    # create a test warmer to pass to the cache
+    Helper.create_warmer(:options_warmer, 50, fn(_) ->
+      { :ok, [ { 1, 1 } ], [ ttl: 60000 ] }
+    end)
+
+    # create a cache instance with a warmer
+    cache = Helper.create_cache([
+      warmers: [ warmer(module: :options_warmer) ]
+    ])
+
+    # wait a while for it to fire
+    :timer.sleep(100)
+
+    # check that the key was warmed
+    assert Cachex.get!(cache, 1) == 1
+
+    # check that there's a TTL
+    assert Cachex.ttl!(cache, 1) != nil
+  end
+
+  test "warmers which don't set values" do
+    # create a test warmer to pass to the cache
+    Helper.create_warmer(:ignore_warmer, 50, fn(_) ->
+      :ignore
+    end)
+
+    # create a cache instance with a warmer
+    cache = Helper.create_cache([
+      warmers: [ warmer(module: :ignore_warmer) ]
+    ])
+
+    # wait a while for it to fire
+    :timer.sleep(100)
+
+    # check that the cache is empty
+    assert Cachex.empty?!(cache)
+  end
+
+
+  test "providing warmers with states" do
+    # create a test warmer to pass to the cache
+    Helper.create_warmer(:state_warmer, 50, fn(state) ->
+      { :ok, [ { "state", state } ] }
+    end)
+
+    # current timestamp to use as state
+    state = :os.timestamp()
+
+    # create a cache instance with a warmer
+    cache = Helper.create_cache([
+      warmers: [ warmer(module: :state_warmer, state: state) ]
+    ])
+
+    # wait a while for it to fire
+    :timer.sleep(100)
+
+    # check that the key was warmed with state
+    assert Cachex.get!(cache, "state") == state
+  end
+end

--- a/test/lib/cachex_case.ex
+++ b/test/lib/cachex_case.ex
@@ -13,6 +13,7 @@ defmodule CachexCase do
       import Cachex.Errors
       import ExUnit.CaptureLog
 
+      require Helper
       require ExecuteHook
       require ForwardHook
     end


### PR DESCRIPTION
This fixes #97 (finally!).

This PR will add `Cachex.Warmer` which provides a behaviour for cache warming. Warmers can be attached to a cache to populate the backing tables on interval, and can populate many keys at once (making them a better fit in a few situations).