### PR TITLE
Normalize stats and remove :missing tags

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -57,7 +57,7 @@ defmodule Cachex do
   @type cache :: atom | Spec.cache
 
   # custom status type
-  @type status :: :ok | :error | :missing
+  @type status :: :ok | :error
 
   # generate unsafe definitions
   @unsafe [
@@ -389,7 +389,7 @@ defmodule Cachex do
       { :ok, 5 }
 
       iex> Cachex.decr(:my_cache, "missing_key", 5, initial: 2)
-      { :missing, -3 }
+      { :ok, -3 }
 
   """
   @spec decr(cache, any, integer, Keyword.t) :: { status, integer }
@@ -415,7 +415,7 @@ defmodule Cachex do
       { :ok, true }
 
       iex> Cachex.get(:my_cache, "key")
-      { :missing, nil }
+      { :ok, nil }
 
   """
   @spec del(cache, any, Keyword.t) :: { status, boolean }
@@ -565,7 +565,7 @@ defmodule Cachex do
       { :ok, true }
 
       iex> Cachex.expire(:my_cache, "missing_key", :timer.seconds(5))
-      { :missing, false }
+      { :ok, false }
 
   """
   @spec expire(cache, any, number, Keyword.t) :: { status, boolean }
@@ -590,7 +590,7 @@ defmodule Cachex do
       { :ok, true }
 
       iex> Cachex.expire_at(:my_cache, "missing_key", 1455728085502)
-      { :missing, false }
+      { :ok, false }
 
   """
   @spec expire_at(cache, binary, number, Keyword.t) :: { status, boolean }
@@ -670,7 +670,7 @@ defmodule Cachex do
       { :ok, "value" }
 
       iex> Cachex.get(:my_cache, "missing_key")
-      { :missing, nil }
+      { :ok, nil }
 
   """
   @spec get(cache, any, Keyword.t) :: { atom, any }
@@ -701,7 +701,7 @@ defmodule Cachex do
       ...>   (nil) -> { :ignore, nil }
       ...>   (val) -> { :commit, [ "value" | val ] }
       ...> end)
-      { :missing, nil }
+      { :ok, nil }
 
   """
   @spec get_and_update(cache, any, function, Keyword.t) :: { status, any }
@@ -762,7 +762,7 @@ defmodule Cachex do
       { :ok, 15 }
 
       iex> Cachex.incr(:my_cache, "missing_key", 5, initial: 2)
-      { :missing, 7 }
+      { :ok, 7 }
 
   """
   @spec incr(cache, any, integer, Keyword.t) :: { status, integer }
@@ -891,14 +891,14 @@ defmodule Cachex do
       ...>    ]
       ...> ])
       iex> Cachex.put(:my_cache, "my_list", [ 1, 2, 3 ])
-      iex> Cachex.invoke(:my_cache, "my_list", :last)
+      iex> Cachex.invoke(:my_cache, :last, "my_list")
       { :ok, 3 }
 
   """
-  @spec invoke(cache, any, atom, Keyword.t) :: any
-  def invoke(cache, key, cmd, options \\ []) when is_list(options) do
+  @spec invoke(cache, atom, any, Keyword.t) :: any
+  def invoke(cache, cmd, key, options \\ []) when is_list(options) do
     Overseer.enforce(cache) do
-      Actions.Invoke.execute(cache, key, cmd, options)
+      Actions.Invoke.execute(cache, cmd, key, options)
     end
   end
 
@@ -939,7 +939,7 @@ defmodule Cachex do
       { :ok, true }
 
       iex> Cachex.persist(:my_cache, "missing_key")
-      { :missing, false }
+      { :ok, false }
 
   """
   @spec persist(cache, any, Keyword.t) :: { status, boolean }
@@ -1054,7 +1054,7 @@ defmodule Cachex do
       { :ok, 5000 }
 
       iex> Cachex.refresh(:my_cache, "missing_key")
-      { :missing, false }
+      { :ok, false }
 
   """
   @spec refresh(cache, any, Keyword.t) :: { status, boolean }
@@ -1246,10 +1246,10 @@ defmodule Cachex do
       { :ok, "value" }
 
       iex> Cachex.get(:my_cache, "key")
-      { :missing, nil }
+      { :ok, nil }
 
       iex> Cachex.take(:my_cache, "missing_key")
-      { :missing, nil }
+      { :ok, nil }
 
   """
   @spec take(cache, any, Keyword.t) :: { status, any }
@@ -1327,7 +1327,7 @@ defmodule Cachex do
       { :ok, nil }
 
       iex> Cachex.ttl(:my_cache, "missing_key")
-      { :missing, nil }
+      { :ok, nil }
 
   """
   @spec ttl(cache, any, Keyword.t) :: { status, number }
@@ -1356,7 +1356,7 @@ defmodule Cachex do
       { :ok, "new_value" }
 
       iex> Cachex.update(:my_cache, "missing_key", "new_value")
-      { :missing, false }
+      { :ok, false }
 
   """
   @spec update(cache, any, any, Keyword.t) :: { status, any }

--- a/lib/cachex/actions.ex
+++ b/lib/cachex/actions.ex
@@ -53,12 +53,8 @@ defmodule Cachex.Actions do
   Note that updates are atomic; either all updates will take place, or none will.
   """
   @spec update(Spec.cache, any, [ tuple ]) :: { :ok, boolean }
-  def update(cache(name: name), key, changes) do
-    case :ets.update_element(name, key, changes) do
-      true  -> { :ok, true }
-      false -> { :missing, false }
-    end
-  end
+  def update(cache(name: name), key, changes),
+    do: { :ok, :ets.update_element(name, key, changes) }
 
   @doc """
   Writes a new entry into a cache.
@@ -68,10 +64,10 @@ defmodule Cachex.Actions do
     do: { :ok, :ets.insert(name, entries) }
 
   @doc """
-  Returns the module used for a write based on a status tag.
+  Returns the module used for a write based on a prior value.
   """
   @spec write_mod(atom) :: atom
-  def write_mod(tag) when tag in [ :missing, :new ],
+  def write_mod(nil),
     do: __MODULE__.Put
   def write_mod(_tag),
     do: __MODULE__.Update
@@ -114,8 +110,8 @@ defmodule Cachex.Actions do
         result = (unquote(body))
 
         if notify do
-           results = Keyword.get(local_opts, :hook_result, result)
-           Informant.broadcast(local_state, message, results)
+          results = Keyword.get(local_opts, :hook_result, result)
+          Informant.broadcast(local_state, message, results)
         end
 
         result

--- a/lib/cachex/actions/fetch.ex
+++ b/lib/cachex/actions/fetch.ex
@@ -32,7 +32,7 @@ defmodule Cachex.Actions.Fetch do
   placed in the cache in order to allow read-through caches.
   """
   defaction fetch(cache() = cache, key, fallback, options) do
-    with { :missing, nil } <- Get.execute(cache, key, const(:notify_false)) do
+    with { :ok, nil } <- Get.execute(cache, key, const(:notify_false)) do
       Courier.dispatch(cache, key, generate_task(cache, fallback, key))
     end
   end

--- a/lib/cachex/actions/get.ex
+++ b/lib/cachex/actions/get.ex
@@ -19,17 +19,13 @@ defmodule Cachex.Actions.Get do
 
   @doc """
   Retrieves a value from inside the cache.
-
-  The returned value will be wrapped in a tagged Tuple to communicate
-  whether it was found in the cache or not. If the Tuple is tagged with
-  the `:missing` tag, the value was not found.
   """
   defaction get(cache() = cache, key, options) do
     case Actions.read(cache, key) do
       entry(value: value) ->
         { :ok, value }
-      _missing ->
-        { :missing, nil }
+      nil ->
+        { :ok, nil }
     end
   end
 end

--- a/lib/cachex/actions/stats.ex
+++ b/lib/cachex/actions/stats.ex
@@ -22,50 +22,25 @@ defmodule Cachex.Actions.Stats do
   If the provided cache does not have statistics enabled, an error will be returned.
   """
   @spec execute(Spec.cache, Keyword.t) :: { :ok, %{ } } | { :error, :stats_disabled }
-  def execute(cache() = cache, options) do
+  def execute(cache() = cache, _options) do
     with { :ok, stats } <- Stats.retrieve(cache) do
-      options
-      |> Keyword.get(:for, [:overview])
-      |> List.wrap
-      |> normalize(stats)
-      |> Enum.sort
-      |> Enum.into(%{})
-      |> wrap(:ok)
+      hits_count = Map.get(stats,   :hits, 0)
+      miss_count = Map.get(stats, :misses, 0)
+
+      case hits_count + miss_count do
+        0 -> { :ok, stats }
+        v ->
+          v
+          |> generate_rates(hits_count, miss_count)
+          |> Map.merge(stats)
+          |> wrap(:ok)
+      end
     end
   end
 
   ###############
   # Private API #
   ###############
-
-  # Normalizes the stats returned from the statistics hook.
-  #
-  # This uses the `:for` option to determine how to format the statistics. If
-  # the `:raw` option has been provided, we just return the raw payload coming
-  # back directly from the statistics server. If the `:for` option has specified
-  # an overview, we do some enriching of the global stats to provide some high
-  # level statistics.
-  defp normalize([ :raw ], stats),
-    do: stats
-  defp normalize([ :overview ], stats) do
-    meta   = Map.get(stats,   :meta, %{ })
-    global = Map.get(stats, :global, %{ })
-
-    hits_count = Map.get(global,  :hitCount, 0)
-    miss_count = Map.get(global, :missCount, 0)
-
-    req_rates = case hits_count + miss_count do
-      0 -> %{ }
-      v -> generate_rates(v, hits_count, miss_count)
-    end
-
-    %{ }
-    |> Map.merge(meta)
-    |> Map.merge(global)
-    |> Map.merge(req_rates)
-  end
-  defp normalize(keys, stats),
-    do: Map.take(stats, keys)
 
   # Generates request rates for statistics map.
   #
@@ -74,23 +49,23 @@ defmodule Cachex.Actions.Stats do
   # potential to divide values by 0, avoiding a crash in the application.
   defp generate_rates(_reqs, 0, misses),
     do: %{
-      hitCount: 0,
-      hitRate: 0.0,
-      missCount: misses,
-      missRate: 100.0
+      hits: 0,
+      misses: misses,
+      hit_rate: 0.0,
+      miss_rate: 100.0
     }
   defp generate_rates(_reqs, hits, 0),
     do: %{
-      hitCount: hits,
-      hitRate: 100.0,
-      missCount: 0,
-      missRate: 0.0
+      hits: hits,
+      misses: 0,
+      hit_rate: 100.0,
+      miss_rate: 0.0
     }
   defp generate_rates(reqs, hits, misses),
     do: %{
-      hitCount: hits,
-      hitRate: (hits / reqs) * 100,
-      missCount: misses,
-      missRate: (misses / reqs) * 100
+      hits: hits,
+      misses: misses,
+      hit_rate: (hits / reqs) * 100,
+      miss_rate: (misses / reqs) * 100
     }
 end

--- a/lib/cachex/actions/take.ex
+++ b/lib/cachex/actions/take.ex
@@ -59,9 +59,9 @@ defmodule Cachex.Actions.Take do
           const(:purge_override_call),
           const(:purge_override_result)
         )
-        { :missing, nil }
+        { :ok, nil }
     end
   end
-  defp handle_take(_missing, _cache),
-    do: { :missing, nil }
+  defp handle_take([], _cache),
+    do: { :ok, nil }
 end

--- a/lib/cachex/actions/touch.ex
+++ b/lib/cachex/actions/touch.ex
@@ -50,6 +50,4 @@ defmodule Cachex.Actions.Touch do
       ttl -> entry_mod_now(ttl: ttl)
     end)
   end
-  defp handle_ttl({ :missing, nil }, _cache, _key),
-    do: { :missing, false }
 end

--- a/lib/cachex/actions/ttl.ex
+++ b/lib/cachex/actions/ttl.ex
@@ -26,12 +26,10 @@ defmodule Cachex.Actions.Ttl do
   """
   defaction ttl(cache() = cache, key, options) do
     case Actions.read(cache, key) do
-      entry(ttl: nil) ->
-        { :ok, nil }
-      entry(touched: touched, ttl: ttl) ->
+      entry(touched: touched, ttl: ttl) when not is_nil(ttl) ->
         { :ok, touched + ttl - now() }
-      _missing ->
-        { :missing, nil }
+      _anything_else ->
+        { :ok, nil }
     end
   end
 end

--- a/lib/cachex/stats.ex
+++ b/lib/cachex/stats.ex
@@ -19,6 +19,7 @@ defmodule Cachex.Stats do
   # add our aliases
   alias Cachex.Options
 
+  # update incrementers
   @update_calls [
     :expire,
     :expire_at,
@@ -134,7 +135,6 @@ defmodule Cachex.Stats do
   # number of pairs being processed when incrementing the `:writes` key.
   defp register_action(stats, { :put_many, [ pairs | _ ] }, { _tag, true }),
     do: increment(stats, [ :writes ], length(pairs))
-
 
   # Handles registration of `del()` command calls.
   #

--- a/lib/cachex/stats.ex
+++ b/lib/cachex/stats.ex
@@ -16,6 +16,18 @@ defmodule Cachex.Stats do
   import Cachex.Spec
   import Cachex.Errors
 
+  # add our aliases
+  alias Cachex.Options
+
+  @update_calls [
+    :expire,
+    :expire_at,
+    :persist,
+    :refresh,
+    :touch,
+    :update
+  ]
+
   ##############
   # Public API #
   ##############
@@ -59,7 +71,7 @@ defmodule Cachex.Stats do
   # at which the statistics container was first created (which is more of less
   # equivalent to the start time of the cache).
   def init(_options),
-    do: { :ok, %{ meta: %{ creationDate: now() } } }
+    do: { :ok, %{ meta: %{ creation_date: now() } } }
 
   @doc false
   # Retrieves the current stats container.
@@ -80,206 +92,200 @@ defmodule Cachex.Stats do
   @doc false
   # Registers an action against the stats container.
   #
-  # This clause will pull out the action from the cache call, as well as the
-  # result, and use both to increment various keys in the statistics container
-  # to signal exactly what the call represents.
+  # This will increment the call count for every action taken on a cache, as
+  # well as incrementing the operation count (although this could be computed
+  # from the call counts).
   #
-  # This is done by passing off to `register_action/2` internally as we use
-  # multiple function head definitions to easily separate action logic.
-  def handle_notify(action, result, stats) do
+  # It will then pass the statistics on to `register_action/3` in order to
+  # allow call specific statistics to be incremented. Note that the order of
+  # `register_action/3` is naively ordered to try and optimize for frequency.
+  def handle_notify({ call, _args } = action, result, stats) do
     stats
+    |> increment([ :calls, call ], 1)
+    |> increment([ :operations ], 1)
     |> register_action(action, result)
-    |> increment(:global, :opCount, 1)
     |> wrap(:ok)
   end
 
-  ###############
-  # Private API #
-  ###############
+  ################
+  # Registration #
+  ################
 
-  # Handles registration of `clear()` command calls.
+  # Handles registration of `get()` command calls.
   #
-  # A clear call returns the number of entries removed, so this will update both
-  # the total number of cleared entries as well as the global eviction count.
-  defp register_action(stats, { :clear, _args }, { _status, value }) do
-    stats
-    |> increment(:clear, :total, value)
-    |> increment(:global, :evictionCount, value)
-  end
-
-  # Handles registration of `del()` command calls.
-  #
-  # Deleting a cache entry should increment the delete count
-  # and also the global eviction count by 1.
-  defp register_action(stats, { :del, _args }, { _status, value }) do
-    tmp = increment(stats, :del, value, 1)
-    case value do
-      true  -> increment(tmp, :global, :evictionCount, 1)
-      false -> tmp
-    end
-  end
-
-  # Handles registration of `exists?()` command calls.
-  #
-  # This needs to increment the global hit/miss count based on the value
-  # boolean coming back. It will also increment the value key under the
-  # `:exists?` action namespace in the statistics container.
-  defp register_action(stats, { :exists?, _args }, { _status, value }) do
-    stats
-    |> increment(:exists?, value, 1)
-    |> increment(:global, value && :hitCount || :missCount, 1)
-  end
-
-  # Handles registration of `purge()` command calls.
-  #
-  # A purge call returns the number of entries removed, so this will update both
-  # the total number of purged entries as well as the global expired count.
-  defp register_action(stats, { :purge, _args }, { _status, value }) do
-    stats
-    |> increment(:purge, :total, value)
-    |> increment(:global, :expiredCount, value)
-  end
+  # This will increment the hits/misses of the stats container, based on
+  # whether the value pulled back is `nil` or not (as `nil` is treated as
+  # a missing value through Cachex as of v3).
+  defp register_action(stats, { :get, _args }, { _tag, nil }),
+    do: increment(stats, [ :misses ], 1)
+  defp register_action(stats, { :get, _args }, { _tag, _value }),
+    do: increment(stats, [ :hits ], 1)
 
   # Handles registration of `put()` command calls.
   #
-  # Set calls will increment the result of the call in the `:put`
-  # namespace inside the statistics container. It will also
-  # increment the global entry set count.
-  defp register_action(stats, { :put, _args }, { _status, value }) do
-    tmp = increment(stats, :put, value, 1)
-    case value do
-      true  -> increment(tmp, :global, :setCount, 1)
-      false -> tmp
-    end
-  end
+  # These calls will just increment the `:writes` count of the statistics
+  # container, but only if the write succeeded (as determined by the value).
+  defp register_action(stats, { :put, _args }, { _tag, true }),
+    do: increment(stats, [ :writes ], 1)
 
   # Handles registration of `put_many()` command calls.
   #
-  # This is the same as the `put()` handler except that it
-  # will count the number of pairs being processed.
-  defp register_action(stats, { :put_many, [ pairs | _ ] }, { _status, value }) do
-    tmp = increment(stats, :put_many, value, 1)
-    case value do
-      true  -> increment(tmp, :global, :setCount, length(pairs))
-      false -> tmp
-    end
+  # This is the same as the `put()` handler except that it will count the
+  # number of pairs being processed when incrementing the `:writes` key.
+  defp register_action(stats, { :put_many, [ pairs | _ ] }, { _tag, true }),
+    do: increment(stats, [ :writes ], length(pairs))
+
+
+  # Handles registration of `del()` command calls.
+  #
+  # Cache deletions will increment the `:evictions` key count, based on
+  # whether the call succeeded (i.e. the result value is truthy).
+  defp register_action(stats, { :del, _args }, { _tag, true }),
+    do: increment(stats, [ :evictions ], 1)
+
+  # Handles registration of `purge()` command calls.
+  #
+  # A purge call will increment the `:evictions` key using the count of
+  # purged keys as the number to increment by. The `:expirations` key
+  # will also be incremented in the same way, to surface TTL deletions.
+  defp register_action(stats, { :purge, _args }, { _status, count }) do
+    stats
+    |> increment([ :expirations ], count)
+    |> increment([ :evictions ], count)
   end
+
+  # Handles registration of `fetch()` command calls.
+  #
+  # This will delegate through to `register_fetch/2` as the logic is
+  # more complicated, and this will keep down the noise of head matches.
+  defp register_action(stats, { :fetch, _args }, { label, _value }),
+    do: register_fetch(stats, label)
+
+  # Handles registration of `incr()` command calls.
+  #
+  # This delegates through to `register_increment/4` as the logic is a
+  # little more complicated, and this will keep down the noise of matches.
+  defp register_action(stats, { :incr, _args } = action, result),
+    do: register_increment(stats, action, result, -1)
+
+  # Handles registration of `decr()` command calls.
+  #
+  # This delegates through to `register_increment/4` as the logic is a
+  # little more complicated, and this will keep down the noise of matches.
+  defp register_action(stats, { :decr, _args } = action, result),
+    do: register_increment(stats, action, result,  1)
+
+  # Handles registration of `update()` command calls.
+  #
+  # This will increment the `:updates` key if the value signals that the
+  # update was successful, otherwise nothing will be modified.
+  defp register_action(stats, { :update, _args }, { _tag, true }),
+    do: increment(stats, [ :updates ], 1)
+
+  # Handles registration of `clear()` command calls.
+  #
+  # This operates in the same way as the `del()` call statistics, except that
+  # a count is received in the result, and is used to increment by instead.
+  defp register_action(stats, { :clear, _args }, { _tag, count }),
+    do: increment(stats, [ :evictions ], count)
+
+  # Handles registration of `exists?()` command calls.
+  #
+  # The result boolean will determine whether this increments the `:hits` or
+  # `:misses` key of the main statistics container (true/false respectively).
+  defp register_action(stats, { :exists?, _args }, { _tag, true }),
+    do: increment(stats, [ :hits ], 1)
+  defp register_action(stats, { :exists?, _args }, { _tag, false }),
+    do: increment(stats, [ :misses ], 1)
 
   # Handles registration of `take()` command calls.
   #
   # Take calls are a little complicated because they need to increment the
   # global eviction count (due to removal) but also increment the global
   # hit/miss count, in addition to the status in the `:take` namespace.
-  defp register_action(stats, { :take, _args }, { status, _value }) do
-    tmp =
-      stats
-      |> increment(:take, status, 1)
-      |> increment(:global, normalize_status(status), 1)
+  defp register_action(stats, { :take, _args }, { _tag, nil }),
+    do: increment(stats, [ :misses ], 1)
+  defp register_action(stats, { :take, _args }, _result) do
+    stats
+    |> increment([ :hits ], 1)
+    |> increment([ :evictions ], 1)
+  end
 
-    case status do
-      :ok -> increment(tmp, :global, :evictionCount, 1)
-      _na -> tmp
+  # Handles registration of `invoke()` command calls.
+  #
+  # This will increment a custom invocations map to track custom command calls.
+  defp register_action(stats, { :invoke, [ cmd | _args ] }, { :ok, _value }),
+    do: increment(stats, [ :invocations, cmd ], 1)
+
+  # Handles registration of updating command calls.
+  #
+  # All of the matches calls (dictated by @update_calls) will increment the main
+  # `:updates` key in the statistics map only if the value is received as `true`.
+  defp register_action(stats, { action, _args }, { _tag, true })
+  when action in @update_calls,
+    do: increment(stats, [ :updates ], 1)
+
+  # No-op to avoid crashing on other statistics.
+  defp register_action(stats, _action, _result),
+    do: stats
+
+  ########################
+  # Registration Helpers #
+  ########################
+
+  # Handles tracking `fetch()` results based on the result tag.
+  #
+  # If there's an `:ok`, the value existed and so the `:hits` stat needs to
+  # be incremented. If not, we need to increment the `:misses` count. In the
+  # case of a miss, we also need to check for `:commit` vs `:ignore` to know
+  # whether we should be updating the `:writes` key too.
+  defp register_fetch(stats, :ok),
+    do: increment(stats, [ :hits ], 1)
+  defp register_fetch(stats, :commit) do
+    stats
+    |> register_fetch(:ignore)
+    |> increment([ :writes ], 1)
+  end
+  defp register_fetch(stats, :ignore) do
+    stats
+    |> increment([ :fetches ], 1)
+    |> increment([ :misses ], 1)
+  end
+
+  # Handles increment calls coming via `incr()` or `decr()`.
+  #
+  # The logic is the same for both, except for the provided offset (which is
+  # basically just a sign flip). It's split out as it's a little more involved
+  # than a basic stat count as we need to reverse the arguments to determine if
+  # there was a new write or an update (based on the initial/amount arguments).
+  defp register_increment(stats, { _type, args }, { _tag, value }, offset) do
+    amount  = Enum.at(args, 1, 1)
+    options = Enum.at(args, 2, [])
+
+    matcher = value + (amount * offset)
+
+    case Options.get(options, :initial, &is_integer/1, 0) do
+      ^matcher ->
+        increment(stats, [ :writes ], 1)
+      _anything_else ->
+        increment(stats, [ :updates ], 1)
     end
   end
 
-  # Handles registration of `ttl()` command calls.
-  #
-  # This will increment the status in the `:ttl` namespace as well
-  # as incrementing the global hit/miss count for the cache.
-  defp register_action(stats, { :ttl, _args }, { status, _value }) do
-    stats
-    |> increment(:ttl, status, 1)
-    |> increment(:global, status == :ok && :hitCount || :missCount, 1)
-  end
+  ##########################
+  # Registration Utilities #
+  ##########################
 
-  # Handles registration of `update()` command calls.
+  # Increments statistics in the statistics container.
   #
-  # This will increment the global update count as well as the value
-  # inside the `:update` namespace, to represent an update hit.
-  defp register_action(stats, { :update, _args }, { _status, value }) do
-    tmp = increment(stats, :update, value, 1)
-    case value do
-      true  -> increment(tmp, :global, :updateCount, 1)
-      false -> tmp
-    end
-  end
-
-  # Handles registration of `get()` and `fetch()` command calls.
-  #
-  # This needs to increment the status in the global container, in addition to adding
-  # the status to the namespace of the provided action (either `:get` or `:fetch`).
-  defp register_action(stats, { action, _args }, { status, _value })
-  when action in [ :get, :fetch ] do
-    stats
-    |> increment(action, status, 1)
-    |> increment(:global, normalize_status(status), 1)
-  end
-
-  # Handles registration of `decr()` and `incr()` command calls.
-  #
-  # Both of these calls operate in the same way, just negative/positive. We use the
-  # status to determine if a new value was inserted or if it was updated. Aside from
-  # this we just increment the status in the action namespace, as always.
-  defp register_action(stats, { action, _args }, { status, _value })
-  when action in [ :decr, :incr ] do
-    stats
-    |> increment(action, status, 1)
-    |> increment(:global, status == :ok && :updateCount || :setCount, 1)
-  end
-
-  # Handles registration of `expire()`, `expire_at()`, `persist()` and `refresh()` calls.
-  #
-  # This is a common set of updates which changes the global update count alongside the
-  # received value in the action namespace, as all of these actions are related and shared.
-  defp register_action(stats, { action, _args }, { _status, value })
-  when action in [ :expire, :expire_at, :persist, :refresh ] do
-    tmp = increment(stats, action, value, 1)
-    case value do
-      true  -> increment(tmp, :global, :updateCount, 1)
-      false -> tmp
-    end
-  end
-
-  # Handles the registration of any other calls.
-  #
-  # This purely increments the action call by 1.
-  defp register_action(stats, { action, _args }, _result),
-    do: increment(stats, action, :calls, 1)
-
-  # Increments a given set of statistics in the stats container.
-  #
-  # We accept a list of fields to work with to increment multiple statistics for
-  # an action at the same time, even though this isn't needed at the time of
-  # writing.
-  #
-  # This is a gross function due to the nesting but it's actually quite optimized
-  # as of Cachex v3. Further changes will happen later in order to make the stats
-  # collection a little more uniform to avoid the complexity involved.
-  defp increment(stats, action, fields, amount) do
-    { _, updated_stats } = Map.get_and_update(stats, action, fn(inner) ->
-      fields_list = List.wrap(fields)
-
-      action_stats =
-        Enum.reduce(fields_list, inner || %{}, fn(key, acc) ->
-          Map.update(acc, key, amount, &(amount + &1))
-        end)
-
-      { nil, action_stats }
+  # This accepts a list of fields to specify the path to the key to increment,
+  # much like the `update_in` provided in more recent versions of Elixir.
+  defp increment(stats, [ head ], amount),
+    do: Map.update(stats, head, amount, &(&1 + amount))
+  defp increment(stats, [ head | tail ], amount) do
+    Map.put(stats, head, case Map.get(stats, head) do
+      nil -> increment(%{}, tail, amount)
+      map -> increment(map, tail, amount)
     end)
-    updated_stats
   end
-
-  # Normalizes a status atom into global fields.
-  #
-  # This is used to get a list of global fields to increment
-  # based on the status returned by an action as it's always
-  # the same behaviour regardless of the action executed.
-  defp normalize_status(:ok),
-    do: [ :hitCount ]
-  defp normalize_status(:missing),
-    do: [ :missCount ]
-  defp normalize_status(:commit),
-    do: [ :missCount, :loadCount, :setCount ]
-  defp normalize_status(:ignore),
-    do: [ :missCount, :loadCount ]
 end

--- a/test/cachex/actions/clear_test.exs
+++ b/test/cachex/actions/clear_test.exs
@@ -37,8 +37,8 @@ defmodule Cachex.Actions.ClearTest do
     value3 = Cachex.get(cache, 3)
 
     # verify the items are gone
-    assert(value1 == { :missing, nil })
-    assert(value2 == { :missing, nil })
-    assert(value3 == { :missing, nil })
+    assert(value1 == { :ok, nil })
+    assert(value2 == { :ok, nil })
+    assert(value3 == { :ok, nil })
   end
 end

--- a/test/cachex/actions/decr_test.exs
+++ b/test/cachex/actions/decr_test.exs
@@ -20,13 +20,13 @@ defmodule Cachex.Actions.DecrTest do
     decr3 = Cachex.decr(cache, "key2", 1, opts1)
 
     # the first result should be -1
-    assert(decr1 == { :missing, -1 })
+    assert(decr1 == { :ok, -1 })
 
     # the second result should be -3
     assert(decr2 == { :ok, -3 })
 
     # the third result should be 9
-    assert(decr3 == { :missing, 9 })
+    assert(decr3 == { :ok, 9 })
 
     # verify the hooks were updated with the decrement
     assert_receive({ { :decr, [ "key1", 1,     [] ] }, ^decr1 })

--- a/test/cachex/actions/del_test.exs
+++ b/test/cachex/actions/del_test.exs
@@ -31,7 +31,7 @@ defmodule Cachex.Actions.DelTest do
     value2 = Cachex.get(cache, 2)
 
     # verify the items are gone
-    assert(value1 == { :missing, nil })
-    assert(value2 == { :missing, nil })
+    assert(value1 == { :ok, nil })
+    assert(value2 == { :ok, nil })
   end
 end

--- a/test/cachex/actions/exists_test.exs
+++ b/test/cachex/actions/exists_test.exs
@@ -48,7 +48,7 @@ defmodule Cachex.Actions.ExistsTest do
 
     # verify the second was removed
     assert(value1 == { :ok, 1 })
-    assert(value2 == { :missing, nil })
-    assert(value3 == { :missing, nil })
+    assert(value2 == { :ok, nil })
+    assert(value3 == { :ok, nil })
   end
 end

--- a/test/cachex/actions/expire_at_test.exs
+++ b/test/cachex/actions/expire_at_test.exs
@@ -41,7 +41,7 @@ defmodule Cachex.Actions.ExpireAtTest do
     assert(result3 == { :ok, true })
 
     # the last one is missing and should fail
-    assert(result4 == { :missing, false })
+    assert(result4 == { :ok, false })
 
     # verify the hooks were updated with the message
     assert_receive({ { :expire_at, [ 1, ^f_expire_time, [] ] }, ^result1 })
@@ -63,7 +63,7 @@ defmodule Cachex.Actions.ExpireAtTest do
     assert_in_delta(ttl2, 10000, 25)
 
     # assert the last two keys don't exist
-    assert(ttl3 == { :missing, nil })
-    assert(ttl4 == { :missing, nil })
+    assert(ttl3 == { :ok, nil })
+    assert(ttl4 == { :ok, nil })
   end
 end

--- a/test/cachex/actions/expire_test.exs
+++ b/test/cachex/actions/expire_test.exs
@@ -38,7 +38,7 @@ defmodule Cachex.Actions.ExpireTest do
     assert(result3 == { :ok, true })
 
     # the last one is missing and should fail
-    assert(result4 == { :missing, false })
+    assert(result4 == { :ok, false })
 
     # verify the hooks were updated with the message
     assert_receive({ { :expire, [ 1, ^f_expire_time, [] ] }, ^result1 })
@@ -60,7 +60,7 @@ defmodule Cachex.Actions.ExpireTest do
     assert_in_delta(ttl2, 10000, 25)
 
     # assert the last two keys don't exist
-    assert(ttl3 == { :missing, nil })
-    assert(ttl4 == { :missing, nil })
+    assert(ttl3 == { :ok, nil })
+    assert(ttl4 == { :ok, nil })
   end
 end

--- a/test/cachex/actions/fetch_test.exs
+++ b/test/cachex/actions/fetch_test.exs
@@ -85,7 +85,7 @@ defmodule Cachex.Actions.FetchTest do
     assert(value2 == { :ok, "4yek" })
 
     # ignored keys should not exist
-    assert(value3 == { :missing, nil })
+    assert(value3 == { :ok, nil })
 
     # check using a missing fallback
     result8 = Cachex.fetch(cache1, "key7")

--- a/test/cachex/actions/get_and_update_test.exs
+++ b/test/cachex/actions/get_and_update_test.exs
@@ -45,18 +45,18 @@ defmodule Cachex.Actions.GetAndUpdateTest do
     end)
 
     # verify the first key is retrieved
-    assert(result1 == { :ok, "1" })
+    assert(result1 == { :commit, "1" })
 
     # verify the second and third keys are missing
-    assert(result2 == { :missing, "" })
-    assert(result3 == { :missing, "" })
+    assert(result2 == { :commit, "" })
+    assert(result3 == { :commit, "" })
 
     # verify the fourth result
-    assert(result4 == { :ok, "4" })
+    assert(result4 == { :commit, "4" })
 
     # verify the fifth and sixth results
-    assert(result5 == { :ok, "5" })
-    assert(result6 == { :ok, "6" })
+    assert(result5 == { :ignore, "5" })
+    assert(result6 == { :commit, "6" })
 
     # assert we receive valid notifications
     assert_receive({ { :get_and_update, [ 1, _to_string, [ ] ] }, ^result1 })

--- a/test/cachex/actions/get_test.exs
+++ b/test/cachex/actions/get_test.exs
@@ -33,8 +33,8 @@ defmodule Cachex.Actions.GetTest do
     assert(result1 == { :ok, 1 })
 
     # verify the second and third keys are missing
-    assert(result2 == { :missing, nil })
-    assert(result3 == { :missing, nil })
+    assert(result2 == { :ok, nil })
+    assert(result3 == { :ok, nil })
 
     # assert we receive valid notifications
     assert_receive({ { :get, [ 1, [ ] ] }, ^result1 })

--- a/test/cachex/actions/incr_test.exs
+++ b/test/cachex/actions/incr_test.exs
@@ -20,13 +20,13 @@ defmodule Cachex.Actions.IncrTest do
     incr3 = Cachex.incr(cache, "key2", 1, opts1)
 
     # the first result should be 1
-    assert(incr1 == { :missing, 1 })
+    assert(incr1 == { :ok, 1 })
 
     # the second result should be 3
     assert(incr2 == { :ok, 3 })
 
     # the third result should be 11
-    assert(incr3 == { :missing, 11 })
+    assert(incr3 == { :ok, 11 })
 
     # verify the hooks were updated with the increment
     assert_receive({ { :incr, [ "key1", 1,     [] ] }, ^incr1 })

--- a/test/cachex/actions/invoke_test.exs
+++ b/test/cachex/actions/invoke_test.exs
@@ -22,10 +22,10 @@ defmodule Cachex.Actions.InvokeTest do
     { :entry, "list", touched, nil, _val } = Cachex.inspect!(cache, { :entry, "list" })
 
     # execute some custom commands
-    lpop1 = Cachex.invoke(cache, "list", :lpop)
-    lpop2 = Cachex.invoke(cache, "list", :lpop)
-    rpop1 = Cachex.invoke(cache, "list", :rpop)
-    rpop2 = Cachex.invoke(cache, "list", :rpop)
+    lpop1 = Cachex.invoke(cache, :lpop, "list")
+    lpop2 = Cachex.invoke(cache, :lpop, "list")
+    rpop1 = Cachex.invoke(cache, :rpop, "list")
+    rpop2 = Cachex.invoke(cache, :rpop, "list")
 
     # verify that all results are as expected
     assert(lpop1 == { :ok, 1 })
@@ -40,8 +40,8 @@ defmodule Cachex.Actions.InvokeTest do
     assert(inspect1 == { :entry, "list", touched, nil, [ ] })
 
     # pop some extras to test avoiding writes
-    lpop3 = Cachex.invoke(cache, "list", :lpop)
-    rpop3 = Cachex.invoke(cache, "list", :rpop)
+    lpop3 = Cachex.invoke(cache, :lpop, "list")
+    rpop3 = Cachex.invoke(cache, :rpop, "list")
 
     # verify we stayed the same
     assert(lpop3 == { :ok, nil })
@@ -65,7 +65,7 @@ defmodule Cachex.Actions.InvokeTest do
       { :ok, true } = Cachex.put(cache, "list", list)
 
       # retrieve the last value
-      last = Cachex.invoke(cache, "list", :last)
+      last = Cachex.invoke(cache, :last, "list")
 
       # compare with the expected
       assert(last == { :ok, expected })
@@ -96,11 +96,11 @@ defmodule Cachex.Actions.InvokeTest do
     })
 
     # try to invoke a missing command
-    invoke1 = Cachex.invoke(state, "heh", :unknowns)
+    invoke1 = Cachex.invoke(state, :unknowns, "heh")
 
     # try to invoke bad arity commands
-    invoke2 = Cachex.invoke(state, "heh", :fake_mod)
-    invoke3 = Cachex.invoke(state, "heh", :fake_ret)
+    invoke2 = Cachex.invoke(state, :fake_mod, "heh")
+    invoke3 = Cachex.invoke(state, :fake_ret, "heh")
 
     # all should error
     assert(invoke1 == { :error, :invalid_command })

--- a/test/cachex/actions/persist_test.exs
+++ b/test/cachex/actions/persist_test.exs
@@ -38,7 +38,7 @@ defmodule Cachex.Actions.PersistTest do
     assert(persist2 == { :ok, true })
 
     # the third shouldn't, as it's missing
-    assert(persist3 == { :missing, false })
+    assert(persist3 == { :ok, false })
 
     # verify the hooks were updated with the message
     assert_receive({ { :persist, [ 1, [] ] }, ^persist1 })

--- a/test/cachex/actions/refresh_test.exs
+++ b/test/cachex/actions/refresh_test.exs
@@ -42,7 +42,7 @@ defmodule Cachex.Actions.RefreshTest do
     assert(refresh2 == { :ok, true })
 
     # the third shouldn't, as it's missing
-    assert(refresh3 == { :missing, false })
+    assert(refresh3 == { :ok, false })
 
     # verify the hooks were updated with the message
     assert_receive({ { :refresh, [ 1, [] ] }, ^refresh1 })

--- a/test/cachex/actions/reset_test.exs
+++ b/test/cachex/actions/reset_test.exs
@@ -4,7 +4,7 @@ defmodule Cachex.Actions.ResetTest do
   # This test ensures that we can reset a cache completely, resetting the state
   # of all hooks and emptying the cache of keys. We verify this using the stats
   # hook and checking the creaionDate (which is set when the hook is started),
-  # and ensuring that the creationDate resets when the cache does. We also verify
+  # and ensuring that the creation_date resets when the cache does. We also verify
   # that the cache is empty after being reset. The second cache here with no hooks
   # is to ensure coverage of clearing a cache with no hooks, as there are optimizations
   # which avoid this from wasting time - this can sadly only be verified using
@@ -27,7 +27,7 @@ defmodule Cachex.Actions.ResetTest do
     stats1 = Cachex.stats!(cache1)
 
     # verify the stats
-    assert_in_delta(stats1.creationDate, ctime1, 10)
+    assert_in_delta(stats1.meta.creation_date, ctime1, 10)
 
     # ensure the cache is not empty
     refute(Cachex."empty?!"(cache1))
@@ -55,7 +55,7 @@ defmodule Cachex.Actions.ResetTest do
     stats2 = Cachex.stats!(cache1)
 
     # verify they reset properly
-    assert_in_delta(stats2.creationDate, ctime2, 10)
+    assert_in_delta(stats2.meta.creation_date, ctime2, 10)
   end
 
   # This test ensures that we can reset a cache without touching any of the hooks
@@ -76,7 +76,7 @@ defmodule Cachex.Actions.ResetTest do
     stats1 = Cachex.stats!(cache)
 
     # verify the stats
-    assert_in_delta(stats1.creationDate, ctime1, 5)
+    assert_in_delta(stats1.meta.creation_date, ctime1, 5)
 
     # ensure the cache is not empty
     refute(Cachex."empty?!"(cache))
@@ -94,15 +94,15 @@ defmodule Cachex.Actions.ResetTest do
     stats2 = Cachex.stats!(cache)
 
     # verify they didn't change
-    assert(stats2.creationDate == stats1.creationDate)
+    assert(stats2.meta.creation_date == stats1.meta.creation_date)
   end
 
   # This test covers the resetting of a cache's hooks, but not resetting the cache
   # itself. We do this by ensuring that the cache never becomes empty, but the
-  # creationDate on the stats hook is reset. Firstly we do a reset with a whitelist
+  # creation_date on the stats hook is reset. Firstly we do a reset with a whitelist
   # of hooks to reset to ensure that this does not reset the stats hook (thus
   # verifying that this works correctly), and then we reset all hooks and check
-  # that the creationDate of the stats hook is reset properly.
+  # that the creation_date of the stats hook is reset properly.
   test "resetting only a cache's hooks" do
     # create a test cache
     cache = Helper.create_cache([ stats: true ])
@@ -117,7 +117,7 @@ defmodule Cachex.Actions.ResetTest do
     stats1 = Cachex.stats!(cache)
 
     # verify the stats
-    assert_in_delta(stats1.creationDate, ctime1, 5)
+    assert_in_delta(stats1.meta.creation_date, ctime1, 5)
 
     # ensure the cache is not empty
     refute(Cachex."empty?!"(cache))
@@ -141,7 +141,7 @@ defmodule Cachex.Actions.ResetTest do
     stats2 = Cachex.stats!(cache)
 
     # verify they don't reset
-    assert(stats2.creationDate == stats1.creationDate)
+    assert(stats2.meta.creation_date == stats1.meta.creation_date)
 
     # reset without a hooks list
     reset2 = Cachex.reset(cache, [ only: :hooks ])
@@ -156,6 +156,6 @@ defmodule Cachex.Actions.ResetTest do
     stats3 = Cachex.stats!(cache)
 
     # verify they don't reset
-    assert_in_delta(stats3.creationDate, ctime2, 5)
+    assert_in_delta(stats3.meta.creation_date, ctime2, 5)
   end
 end

--- a/test/cachex/actions/stats_test.exs
+++ b/test/cachex/actions/stats_test.exs
@@ -16,56 +16,19 @@ defmodule Cachex.Actions.StatsTest do
     { :ok,    1 } = Cachex.get(cache, 1)
 
     # retrieve default stats
-    stats1 = Cachex.stats!(cache)
+    stats = Cachex.stats!(cache)
 
-    # retrieve global stats
-    stats2 = Cachex.stats!(cache, [ for: [ :global, :get ] ])
+    # verify the first returns a valid meta object
+    assert_in_delta(stats.meta.creation_date, ctime, 5)
 
-    # retrieve specific stats
-    stats3 = Cachex.stats!(cache, [ for: [ :get, :put ] ])
+    # verify attached statistics
+    assert(stats.hits == 1)
+    assert(stats.misses == 0)
+    assert(stats.operations == 2)
+    assert(stats.writes == 1)
 
-    # retrieve raw stats
-    stats4 = Cachex.stats!(cache, [ for: :raw ])
-
-    # verify the first returns a default stat struct
-    assert_in_delta(stats1.creationDate, ctime, 5)
-    assert(stats1.hitCount == 1)
-    assert(stats1.hitRate == 100)
-    assert(stats1.missRate == 0)
-    assert(stats1.opCount == 2)
-    assert(stats1.setCount == 1)
-
-    # verify the second returns the global entries under a global key
-    assert(stats2 == %{
-      get: %{
-        ok: 1
-      },
-      global: %{
-        hitCount: 1,
-        opCount: 2,
-        setCount: 1
-      }
-    })
-
-    # verify the third returns only get/set stats
-    assert(stats3 == %{
-      get: %{
-        ok: 1
-      },
-      put: %{
-        true: 1
-      }
-    })
-
-    # verify the fourth returns an entire payload
-    assert_in_delta(stats4.meta.creationDate, ctime, 5)
-    assert(stats4.get == %{ ok: 1 })
-    assert(stats4.global == %{
-      hitCount: 1,
-      opCount: 2,
-      setCount: 1
-    })
-    assert(stats4.put == %{ true: 1 })
+    # verify attached rates
+    assert(stats.hit_rate == 100)
   end
 
   # This test just verifies that we receive an error trying to retrieve stats
@@ -91,17 +54,8 @@ defmodule Cachex.Actions.StatsTest do
     cache3 = Helper.create_cache([ stats: true ])
     cache4 = Helper.create_cache([ stats: true ])
 
-    # retrieve stats with no rates
-    stats1 = Cachex.stats!(cache1)
-
-    # get the stats keys
-    keys1 = Map.keys(stats1)
-
-    # there's nothing in the overview until something happens
-    assert(keys1 == [ :creationDate ])
-
     # set cache1 to 100% misses
-    { :missing, nil } = Cachex.get(cache1, 1)
+    { :ok,  nil } = Cachex.get(cache1, 1)
 
     # set cache2 to 100% hits
     { :ok, true } = Cachex.put(cache2, 1, 1)
@@ -110,61 +64,75 @@ defmodule Cachex.Actions.StatsTest do
     # set cache3 to be 50% each way
     { :ok, true } = Cachex.put(cache3, 1, 1)
     { :ok,    1 } = Cachex.get(cache3, 1)
-    { :missing, nil } = Cachex.get(cache3, 2)
+    { :ok,  nil } = Cachex.get(cache3, 2)
 
     # set cache4 to have some loads
     { :commit, 1 } = Cachex.fetch(cache4, 1, &(&1))
 
     # retrieve all cache rates
-    stats2 = Cachex.stats!(cache1)
-    stats3 = Cachex.stats!(cache2)
-    stats4 = Cachex.stats!(cache3)
-    stats5 = Cachex.stats!(cache4)
+    stats1 = Cachex.stats!(cache1)
+    stats2 = Cachex.stats!(cache2)
+    stats3 = Cachex.stats!(cache3)
+    stats4 = Cachex.stats!(cache4)
 
-    # remove the creationDate
-    stats2 = Map.delete(stats2, :creationDate)
-    stats3 = Map.delete(stats3, :creationDate)
-    stats4 = Map.delete(stats4, :creationDate)
-    stats5 = Map.delete(stats5, :creationDate)
+    # remove the metadata from the stats
+    stats1 = Map.delete(stats1, :meta)
+    stats2 = Map.delete(stats2, :meta)
+    stats3 = Map.delete(stats3, :meta)
+    stats4 = Map.delete(stats4, :meta)
 
     # verify a 100% miss rate for cache1
-    assert(stats2 == %{
-      hitCount: 0,
-      hitRate: 0.0,
-      missCount: 1,
-      missRate: 100.0,
-      opCount: 1
+    assert(stats1 == %{
+      hits: 0,
+      hit_rate: 0.0,
+      misses: 1,
+      miss_rate: 100.0,
+      operations: 1,
+      calls: %{
+        get: 1
+      }
     })
 
     # verify a 100% hit rate for cache2
-    assert(stats3 == %{
-      hitCount: 1,
-      hitRate: 100.0,
-      missCount: 0,
-      missRate: 0.0,
-      opCount: 2,
-      setCount: 1
+    assert(stats2 == %{
+      hits: 1,
+      hit_rate: 100.0,
+      misses: 0,
+      miss_rate: 0.0,
+      operations: 2,
+      writes: 1,
+      calls: %{
+        get: 1,
+        put: 1
+      }
     })
 
     # verify a 50% hit rate for cache3
-    assert(stats4 == %{
-      hitCount: 1,
-      hitRate: 50.0,
-      missCount: 1,
-      missRate: 50.0,
-      opCount: 3,
-      setCount: 1
+    assert(stats3 == %{
+      hits: 1,
+      hit_rate: 50.0,
+      misses: 1,
+      miss_rate: 50.0,
+      operations: 3,
+      writes: 1,
+      calls: %{
+        get: 2,
+        put: 1
+      }
     })
 
     # verify a load count for cache4
-    assert(stats5 == %{
-      hitCount: 0,
-      hitRate: 0.0,
-      loadCount: 1,
-      missCount: 1,
-      missRate: 100.0,
-      opCount: 1,
-      setCount: 1
+    assert(stats4 == %{
+      hits: 0,
+      hit_rate: 0.0,
+      fetches: 1,
+      misses: 1,
+      miss_rate: 100.0,
+      operations: 1,
+      writes: 1,
+      calls: %{
+        fetch: 1
+      }
     })
   end
 end

--- a/test/cachex/actions/take_test.exs
+++ b/test/cachex/actions/take_test.exs
@@ -32,8 +32,8 @@ defmodule Cachex.Actions.TakeTest do
     assert(result1 == { :ok, 1 })
 
     # verify the second and third keys are missing
-    assert(result2 == { :missing, nil })
-    assert(result3 == { :missing, nil })
+    assert(result2 == { :ok, nil })
+    assert(result3 == { :ok, nil })
 
     # assert we receive valid notifications
     assert_receive({ { :take, [ 1, [ ] ] }, ^result1 })

--- a/test/cachex/actions/touch_test.exs
+++ b/test/cachex/actions/touch_test.exs
@@ -45,7 +45,7 @@ defmodule Cachex.Actions.TouchTest do
     assert(touch2 == { :ok, true })
 
     # the third shouldn't, as it's missing
-    assert(touch3 == { :missing, false })
+    assert(touch3 == { :ok, false })
 
     # verify the hooks were updated with the message
     assert_receive({ { :touch, [ 1, [] ] }, ^touch1 })

--- a/test/cachex/actions/ttl_test.exs
+++ b/test/cachex/actions/ttl_test.exs
@@ -26,6 +26,6 @@ defmodule Cachex.Actions.TtlTest do
     assert_in_delta(ttl2, 10000, 10)
 
     # the third should return a missing value
-    assert(ttl3 == { :missing, nil })
+    assert(ttl3 == { :ok, nil })
   end
 end

--- a/test/cachex/actions/update_test.exs
+++ b/test/cachex/actions/update_test.exs
@@ -53,7 +53,7 @@ defmodule Cachex.Actions.UpdateTest do
     update2 = Cachex.update(cache, 2, 3)
 
     # ensure both failed
-    assert(update1 == { :missing, false })
-    assert(update2 == { :missing, false })
+    assert(update1 == { :ok, false })
+    assert(update2 == { :ok, false })
   end
 end

--- a/test/cachex/actions_test.exs
+++ b/test/cachex/actions_test.exs
@@ -89,7 +89,7 @@ defmodule Cachex.ActionsTest do
     assert(update1 == { :ok, true })
 
     # the second is missing
-    assert(update2 == { :missing, false })
+    assert(update2 == { :ok, false })
 
     # retrieve the value
     value2 = Cachex.Actions.read(state, "key")
@@ -177,19 +177,16 @@ defmodule Cachex.ActionsTest do
   end
 
   # This test just provides basic coverage of the write_mod function, by using
-  # tags to determine the correct Action to use to write a value. We make sure
-  # that the :missing and :new tags define a Set and the others define an Update.
+  # a prior value to determine the correct Action to use to write a value.
   test "retrieving a module name to write with" do
     # ask for some modules
-    result1 = Cachex.Actions.write_mod(:new)
-    result2 = Cachex.Actions.write_mod(:missing)
-    result3 = Cachex.Actions.write_mod(:unknown)
+    result1 = Cachex.Actions.write_mod(nil)
+    result2 = Cachex.Actions.write_mod("value")
 
-    # the first two should be Set actions
+    # the first should be Set actions
     assert(result1 == Cachex.Actions.Put)
-    assert(result2 == Cachex.Actions.Put)
 
-    # the third should be an Update
-    assert(result3 == Cachex.Actions.Update)
+    # the second should be an Update
+    assert(result2 == Cachex.Actions.Update)
   end
 end

--- a/test/cachex/stats_test.exs
+++ b/test/cachex/stats_test.exs
@@ -7,23 +7,28 @@ defmodule Cachex.StatsTest do
   # the same number. The operation count in the global namespace also increments
   # by 1 (as clearing is a single cache op).
   test "registering clear actions" do
-    # create our base stats
-    stats = %{ }
+    # create a test cache
+    cache = Helper.create_cache([ stats: true ])
 
-    # define our results
-    payload = { :ok, 5 }
+    # set a few values in the cache
+    for i <- 0..4 do
+      { :ok, true } = Cachex.put(cache, i, i)
+    end
 
-    # registry the payload
-    { :ok, results } = Cachex.Stats.handle_notify({ :clear, [] }, payload, stats)
+    # clear the cache values
+    { :ok, 5 } = Cachex.clear(cache)
 
-    # verify the results
-    assert(results == %{
-      clear: %{
-        total: 5
-      },
-      global: %{
-        evictionCount: 5,
-        opCount: 1
+    # retrieve the statistics
+    { :ok, stats } = stats_no_meta(cache)
+
+    # verify the statistics
+    assert(stats == %{
+      operations: 6,
+      evictions: 5,
+      writes: 5,
+      calls: %{
+        clear: 1,
+        put: 5
       }
     })
   end
@@ -32,28 +37,29 @@ defmodule Cachex.StatsTest do
   # the eviction count only in case of a successful eviction. We also increment
   # the result of the call (which is either true or false) under the del namespace.
   test "registering delete actions" do
-    # create our base stats
-    stats = %{ }
+    # create a test cache
+    cache = Helper.create_cache([ stats: true ])
 
-    # define our results
-    payload1 = { :ok, true }
-    payload2 = { :ok, false }
+    # set a few values in the cache
+    for i <- 0..1 do
+      { :ok, true } = Cachex.put(cache, i, i)
+    end
 
-    # register the first payload
-    { :ok, results1 } = Cachex.Stats.handle_notify({ :del, [] }, payload1, stats)
+    # delete our cache values
+    { :ok, true } = Cachex.del(cache, 0)
+    { :ok, true } = Cachex.del(cache, 1)
 
-    # register the second payload
-    { :ok, results2 } = Cachex.Stats.handle_notify({ :del, [] }, payload2, results1)
+    # retrieve the statistics
+    { :ok, stats } = stats_no_meta(cache)
 
-    # verify the results
-    assert(results2 == %{
-      del: %{
-        true: 1,
-        false: 1
-      },
-      global: %{
-        evictionCount: 1,
-        opCount: 2
+    # verify the statistics
+    assert(stats == %{
+      operations: 4,
+      evictions: 2,
+      writes: 2,
+      calls: %{
+        del: 2,
+        put: 2
       }
     })
   end
@@ -62,29 +68,30 @@ defmodule Cachex.StatsTest do
   # inside the global and exists namespaces. We increment hit/miss counters in
   # the global namespace based on whether the key exists or not.
   test "registering exists? actions" do
-    # create our base stats
-    stats = %{ }
+    # create a test cache
+    cache = Helper.create_cache([ stats: true ])
 
-    # define our results
-    payload1 = { :ok,  true }
-    payload2 = { :ok, false }
+    # set a value in the cache
+    { :ok, true } = Cachex.put(cache, 1, 1)
 
-    # register the first payload
-    { :ok, results1 } = Cachex.Stats.handle_notify({ :exists?, [] }, payload1, stats)
+    # check for a couple of keys
+    { :ok,  true } = Cachex.exists?(cache, 1)
+    { :ok, false } = Cachex.exists?(cache, 2)
 
-    # register the second payload
-    { :ok, results2 } = Cachex.Stats.handle_notify({ :exists?, [] }, payload2, results1)
+    # retrieve the statistics
+    { :ok, stats } = stats_no_meta(cache)
 
-    # verify the combined results
-    assert(results2 == %{
-      exists?: %{
-        true: 1,
-        false: 1
-      },
-      global: %{
-        hitCount: 1,
-        missCount: 1,
-        opCount: 2
+    # verify the statistics
+    assert(stats == %{
+      operations: 3,
+      writes: 1,
+      hits: 1,
+      misses: 1,
+      hit_rate: 50.0,
+      miss_rate: 50.0,
+      calls: %{
+        exists?: 2,
+        put: 1
       }
     })
   end
@@ -92,29 +99,30 @@ defmodule Cachex.StatsTest do
   # Retrieving a key will increment the hit/miss counts
   # based on whether the key was in the cache.
   test "registering get actions" do
-    # create our base stats
-    stats = %{ }
+    # create a test cache
+    cache = Helper.create_cache([ stats: true ])
 
-    # define our results
-    payload1 = { :ok, "values" }
-    payload2 = { :missing, nil }
+    # set a value in the cache
+    { :ok, true } = Cachex.put(cache, 1, 1)
 
-    # register the first payload
-    { :ok, results1 } = Cachex.Stats.handle_notify({ :get, [] }, payload1, stats)
+    # check for a couple of keys
+    { :ok,   1 } = Cachex.get(cache, 1)
+    { :ok, nil } = Cachex.get(cache, 2)
 
-    # register the second payload
-    { :ok, results2 } = Cachex.Stats.handle_notify({ :get, [] }, payload2, results1)
+    # retrieve the statistics
+    { :ok, stats } = stats_no_meta(cache)
 
-    # verify the combined results
-    assert(results2 == %{
-      get: %{
-        missing: 1,
-        ok: 1
-      },
-      global: %{
-        hitCount: 1,
-        missCount: 1,
-        opCount: 2
+    # verify the statistics
+    assert(stats == %{
+      operations: 3,
+      writes: 1,
+      hits: 1,
+      misses: 1,
+      hit_rate: 50.0,
+      miss_rate: 50.0,
+      calls: %{
+        get: 2,
+        put: 1
       }
     })
   end
@@ -123,41 +131,114 @@ defmodule Cachex.StatsTest do
   # key was in the cache, missing, or loaded via a fallback. Note that a fallback
   # will also increment the miss count (as a key must miss in order to fall back).
   test "registering fetch actions" do
-    # create our base stats
-    stats = %{ }
+    # create a test cache
+    cache = Helper.create_cache([ stats: true ])
 
-    # define our results
-    payload1 = { :ok, "values" }
-    payload2 = { :missing, nil }
-    payload3 = { :commit, "na" }
-    payload4 = { :ignore, "na" }
+    # set a value in the cache
+    { :ok, true } = Cachex.put(cache, 1, 1)
 
-    # register the first payload
-    { :ok, results1 } = Cachex.Stats.handle_notify({ :fetch, [] }, payload1, stats)
+    # fetch an existing value
+    { :ok,        1 } = Cachex.fetch(cache, 1, fn _ -> { :commit, "na" } end)
+    { :commit, "na" } = Cachex.fetch(cache, 2, fn _ -> { :commit, "na" } end)
+    { :ignore, "na" } = Cachex.fetch(cache, 3, fn _ -> { :ignore, "na" } end)
 
-    # register the second payload
-    { :ok, results2 } = Cachex.Stats.handle_notify({ :fetch, [] }, payload2, results1)
+    # retrieve the statistics
+    { :ok, stats } = stats_no_meta(cache)
 
-    # register the third payload
-    { :ok, results3 } = Cachex.Stats.handle_notify({ :fetch, [] }, payload3, results2)
+    # verify the statistics
+    assert(stats == %{
+      operations: 4,
+      fetches: 2,
+      writes: 2,
+      hits: 1,
+      hit_rate: (1 / 3) * 100,
+      misses: 2,
+      miss_rate: ((1 / 3) * 2) * 100,
+      calls: %{
+        fetch: 3,
+        put: 1
+      }
+    })
+  end
 
-    # register the fourth payload
-    { :ok, results4 } = Cachex.Stats.handle_notify({ :fetch, [] }, payload4, results3)
+  # These actions can update if the key exists, or set if the key does not exist.
+  # This test will ensure both are done correctly, and appropriately to the result
+  # of the action. If the key misses, we increment the setCount, if it hits we
+  # increment the updateCount. Both increment the operation count.
+  test "registering incr/decr actions" do
+    # create a test cache
+    cache = Helper.create_cache([ stats: true ])
 
-    # verify the combined results
-    assert(results4 == %{
-      fetch: %{
-        commit: 1,
-        ignore: 1,
-        missing: 1,
-        ok: 1
+    # incr values in the cache
+    { :ok, 5 } = Cachex.incr(cache, 1, 3, initial: 2)
+    { :ok, 6 } = Cachex.incr(cache, 1)
+
+    # decr values in the cache
+    { :ok, -5 } = Cachex.decr(cache, 2, 3, initial: -2)
+    { :ok, -6 } = Cachex.decr(cache, 2)
+
+    # retrieve the statistics
+    { :ok, stats } = stats_no_meta(cache)
+
+    # verify the statistics
+    assert(stats == %{
+      operations: 4,
+      updates: 2,
+      writes: 2,
+      calls: %{
+        incr: 2,
+        decr: 2
+      }
+    })
+  end
+
+  test "registering invoke actions" do
+    # define some custom commands
+    last = &List.last/1
+    lpop = fn
+      ([ head | tail ]) ->
+        { head, tail }
+      ([ ] = list) ->
+        {  nil, list }
+    end
+
+    # create a test cache
+    cache = Helper.create_cache([
+      stats: true,
+      commands: [
+        last: command(type:  :read, execute: last),
+        lpop: command(type: :write, execute: lpop)
+      ]
+    ])
+
+    # put the base value
+    { :ok, true } = Cachex.put(cache, "list", [ 1, 2, 3 ])
+
+    # run each command
+    { :ok, 3 } = Cachex.invoke(cache, :last, "list")
+    { :ok, 1 } = Cachex.invoke(cache, :lpop, "list")
+
+    # retrieve the statistics
+    { :ok, stats } = stats_no_meta(cache)
+
+    # verify the statistics
+    assert(stats == %{
+      operations: 6,
+      updates: 1,
+      writes: 1,
+      hits: 2,
+      hit_rate: 100.0,
+      misses: 0,
+      miss_rate: 0.0,
+      invocations: %{
+        last: 1,
+        lpop: 1
       },
-      global: %{
-        hitCount: 1,
-        loadCount: 2,
-        missCount: 3,
-        opCount: 4,
-        setCount: 1
+      calls: %{
+        get: 2,
+        invoke: 2,
+        put: 1,
+        update: 1
       }
     })
   end
@@ -166,23 +247,32 @@ defmodule Cachex.StatsTest do
   # incrementing the expiredCount in the global namespace rather than the typical
   # evictionCount. This is because purged keys are removed due to TTL expiration.
   test "registering purge actions" do
-    # create our base stats
-    stats = %{ }
+    # create a test cache
+    cache = Helper.create_cache([ stats: true ])
 
-    # define our results
-    payload = { :ok, 5 }
+    # set a few values in the cache
+    for i <- 0..4 do
+      { :ok, true } = Cachex.put(cache, i, i, ttl: 1)
+    end
 
-    # register the payload
-    { :ok, results } = Cachex.Stats.handle_notify({ :purge, [] }, payload, stats)
+    # ensure purge
+    :timer.sleep(5)
 
-    # verify the combined results
-    assert(results == %{
-      purge: %{
-        total: 5
-      },
-      global: %{
-        expiredCount: 5,
-        opCount: 1
+    # purge the cache values
+    { :ok, 5 } = Cachex.purge(cache)
+
+    # retrieve the statistics
+    { :ok, stats } = stats_no_meta(cache)
+
+    # verify the statistics
+    assert(stats == %{
+      expirations: 5,
+      operations: 6,
+      evictions: 5,
+      writes: 5,
+      calls: %{
+        purge: 1,
+        put: 5
       }
     })
   end
@@ -191,28 +281,23 @@ defmodule Cachex.StatsTest do
   # global namespace, but otherwise only the false key is incremented inside the
   # set namespace, in order to avoid false positives.
   test "registering put actions" do
-    # create our base stats
-    stats = %{ }
+    # create a test cache
+    cache = Helper.create_cache([ stats: true ])
 
-    # define our results
-    payload1 = { :ok, true }
-    payload2 = { :ok, false }
+    # set a few values in the cache
+    for i <- 0..4 do
+      { :ok, true } = Cachex.put(cache, i, i)
+    end
 
-    # register the first payload
-    { :ok, results1 } = Cachex.Stats.handle_notify({ :put, [] }, payload1, stats)
+    # retrieve the statistics
+    { :ok, stats } = stats_no_meta(cache)
 
-    # register the second payload
-    { :ok, results2 } = Cachex.Stats.handle_notify({ :put, [] }, payload2, results1)
-
-    # verify the combined results
-    assert(results2 == %{
-      put: %{
-        true: 1,
-        false: 1
-      },
-      global: %{
-        opCount: 2,
-        setCount: 1
+    # verify the statistics
+    assert(stats == %{
+      operations: 5,
+      writes: 5,
+      calls: %{
+        put: 5
       }
     })
   end
@@ -220,32 +305,23 @@ defmodule Cachex.StatsTest do
   # This operates in the same way as the test cases above, but verifies that
   # writing a batch will correctly count using the length of the batch itself.
   test "registering put_many actions" do
-    # create our base stats
-    stats = %{ }
+    # create a test cache
+    cache = Helper.create_cache([ stats: true ])
 
-    # define our results
-    payload1 = { :ok, false }
-    payload2 = { :ok, true }
+    # set a few values in the cache
+    { :ok, true } = Cachex.put_many(cache, [
+      { 1, 1 }, { 2, 2 }, { 3, 3 }, { 4, 4 }, { 5, 5 }
+    ])
 
-    # define our batches
-    batch1 = [ { "key", "value" } ]
-    batch2 = [ { "key", "value" }, { "yek", "eulav" } ]
+    # retrieve the statistics
+    { :ok, stats } = stats_no_meta(cache)
 
-    # register the first payload
-    { :ok, results1 } = Cachex.Stats.handle_notify({ :put_many, [ batch1 ] }, payload1, stats)
-
-    # register the second payload
-    { :ok, results2 } = Cachex.Stats.handle_notify({ :put_many, [ batch2 ] }, payload2, results1)
-
-    # verify the combined results
-    assert(results2 == %{
-      put_many: %{
-        true: 1,
-        false: 1
-      },
-      global: %{
-        opCount: 2,
-        setCount: 2
+    # verify the statistics
+    assert(stats == %{
+      operations: 1,
+      writes: 5,
+      calls: %{
+        put_many: 1
       }
     })
   end
@@ -255,149 +331,31 @@ defmodule Cachex.StatsTest do
   # as well as the hitCount. If the key is not in the cache, then we increment the
   # missCount instead. Both also increment keys inside the take namespace.
   test "registering take actions" do
-    # create our base stats
-    stats = %{ }
+    # create a test cache
+    cache = Helper.create_cache([ stats: true ])
 
-    # define our results
-    payload1 = { :ok, "values" }
-    payload2 = { :missing, nil }
+    # set a value in the cache
+    { :ok, true } = Cachex.put(cache, 1, 1)
 
-    # register the first payload
-    { :ok, results1 } = Cachex.Stats.handle_notify({ :take, [] }, payload1, stats)
+    # delete our cache values
+    { :ok, 1 } = Cachex.take(cache, 1)
+    { :ok, nil } = Cachex.take(cache, 2)
 
-    # register the second payload
-    { :ok, results2 } = Cachex.Stats.handle_notify({ :take, [] }, payload2, results1)
+    # retrieve the statistics
+    { :ok, stats } = stats_no_meta(cache)
 
-    # verify the combined results
-    assert(results2 == %{
-      take: %{
-        ok: 1,
-        missing: 1
-      },
-      global: %{
-        opCount: 2,
-        evictionCount: 1,
-        hitCount: 1,
-        missCount: 1
-      }
-    })
-  end
-
-  # This test ensures that checking the TTL on a key correctly registers the stats
-  # associated with the action. If the key doesn't exist, we ensure to increment
-  # the miss count, otherwise we return the hit count. Both increment the op count.
-  test "registering ttl actions" do
-    # create our base stats
-    stats = %{ }
-
-    # define our results
-    payload1 = { :ok, "values" }
-    payload2 = { :missing, nil }
-
-    # register the first payload
-    { :ok, results1 } = Cachex.Stats.handle_notify({ :ttl, [] }, payload1, stats)
-
-    # register the second payload
-    { :ok, results2 } = Cachex.Stats.handle_notify({ :ttl, [] }, payload2, results1)
-
-    # verify the combined results
-    assert(results2 == %{
-      ttl: %{
-        ok: 1,
-        missing: 1
-      },
-      global: %{
-        opCount: 2,
-        hitCount: 1,
-        missCount: 1
-      }
-    })
-  end
-
-  # Update actions increment true/false based on whether the key exists or not.
-  # They also incrment the updateCount key inside the global namespace based on
-  # whether they were successful or not.
-  test "registering update actions" do
-    # create our base stats
-    stats = %{ }
-
-    # define our results
-    payload1 = { :ok, true }
-    payload2 = { :missing, false }
-
-    # register the results
-    { :ok, new_stats } = Cachex.Stats.handle_notify({ :expire, [] },    payload1,  stats)
-    { :ok, new_stats } = Cachex.Stats.handle_notify({ :expire, [] },    payload2,  new_stats)
-    { :ok, new_stats } = Cachex.Stats.handle_notify({ :expire_at, [] }, payload1,  new_stats)
-    { :ok, new_stats } = Cachex.Stats.handle_notify({ :expire_at, [] }, payload2,  new_stats)
-    { :ok, new_stats } = Cachex.Stats.handle_notify({ :persist, [] },   payload1,  new_stats)
-    { :ok, new_stats } = Cachex.Stats.handle_notify({ :persist, [] },   payload2,  new_stats)
-    { :ok, new_stats } = Cachex.Stats.handle_notify({ :refresh, [] },   payload1,  new_stats)
-    { :ok, new_stats } = Cachex.Stats.handle_notify({ :refresh, [] },   payload2,  new_stats)
-    { :ok, new_stats } = Cachex.Stats.handle_notify({ :update, [] },    payload1,  new_stats)
-    { :ok, new_stats } = Cachex.Stats.handle_notify({ :update, [] },    payload2,  new_stats)
-
-    # verify the combined results
-    assert(new_stats == %{
-      expire: %{
-        true: 1,
-        false: 1
-      },
-      expire_at: %{
-        true: 1,
-        false: 1
-      },
-      persist: %{
-        true: 1,
-        false: 1
-      },
-      refresh: %{
-        true: 1,
-        false: 1
-      },
-      update: %{
-        true: 1,
-        false: 1
-      },
-      global: %{
-        opCount: 10,
-        updateCount: 5
-      }
-    })
-  end
-
-  # These actions can update if the key exists, or set if the key does not exist.
-  # This test will ensure both are done correctly, and appropriately to the result
-  # of the action. If the key misses, we increment the setCount, if it hits we
-  # increment the updateCount. Both increment the operation count.
-  test "registering actions which can set or update" do
-    # create our base stats
-    stats = %{ }
-
-    # define our results
-    payload1 = { :ok, true }
-    payload2 = { :missing, false }
-
-    # register the results
-    { :ok, new_stats } = Cachex.Stats.handle_notify({ :incr, [] }, payload1, stats)
-    { :ok, new_stats } = Cachex.Stats.handle_notify({ :incr, [] }, payload2, new_stats)
-    { :ok, new_stats } = Cachex.Stats.handle_notify({ :decr, [] }, payload1, new_stats)
-    { :ok, new_stats } = Cachex.Stats.handle_notify({ :decr, [] }, payload2, new_stats)
-
-    # verify the combined results
-    assert(new_stats == %{
-      decr: %{
-        ok: 1,
-        missing: 1
-      },
-      incr: %{
-        ok: 1,
-        missing: 1
-      },
-      global: %{
-        opCount: 4,
-        setCount: 2,
-        updateCount: 2
+    # verify the statistics
+    assert(stats == %{
+      operations: 3,
+      evictions: 1,
+      writes: 1,
+      hits: 1,
+      hit_rate: 50.0,
+      misses: 1,
+      miss_rate: 50.0,
+      calls: %{
+        put: 1,
+        take: 2
       }
     })
   end
@@ -422,9 +380,17 @@ defmodule Cachex.StatsTest do
     { :ok, stats } = Cachex.Stats.retrieve(cache)
 
     # verify the state of the stats
-    assert_in_delta(stats.meta.creationDate, ctime, 5)
-    assert(stats.get == %{ ok: 1 })
-    assert(stats.global == %{ hitCount: 1, opCount: 2, setCount: 1 })
-    assert(stats.put == %{ true: 1 })
+    assert_in_delta(stats.meta.creation_date, ctime, 5)
+    assert(stats.calls == %{ get: 1, put: 1 })
+    assert(stats.hits == 1)
+    assert(stats.writes == 1)
+    assert(stats.operations == 2)
+  end
+
+  # Retrieves stats with no :meta field
+  defp stats_no_meta(cache) do
+    with { :ok, stats } <- Cachex.stats(cache) do
+      { :ok, Map.delete(stats, :meta) }
+    end
   end
 end


### PR DESCRIPTION
This fixes #128 and fixes #151. 

This will normalize statistics to be a lot clearer and follow a simple (and faster) approach to modifications. It's a lot easier to work with, and makes a lot more sense given why people track cache state in the first place. Due to this, the `:missing` tag has been removed in favour of just treating `nil` as a missing value. This has almost no impact, except there's a rare edge case with false positives on `incr` counting as a fresh write when it's actually an update; but I believe this is a fair trade-off for the simplification on everything else.

This will also (finally) make the stats tests use actual actions, rather than mocking directly to the GenServer calls. 