### PR TITLE
get_and_update/4 typespec is incorrect #182

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -716,7 +716,7 @@ defmodule Cachex do
       { :ignore, nil }
 
   """
-  @spec get_and_update(cache, any, function, Keyword.t) :: { status, any }
+  @spec get_and_update(cache, any, function, Keyword.t) :: { :commit | :ignore, any }
   def get_and_update(cache, key, update_function, options \\ [])
   when is_function(update_function) and is_list(options) do
     Overseer.enforce(cache) do


### PR DESCRIPTION
The typespec indicates that this function returns a tuple of :ok or :error,
but in fact it returns :commit or :ignore tuples.

Updates the typespec return.