### PR TITLE
Enum.find_value instead of Enum.find

### DIFF
--- a/lib/cachex/services.ex
+++ b/lib/cachex/services.ex
@@ -62,7 +62,7 @@ defmodule Cachex.Services do
   """
   @spec locate(Spec.cache, atom) :: pid | nil
   def locate(cache() = cache, service) do
-    Enum.find(services(cache), fn
+    Enum.find_value(services(cache), fn
       ({ ^service, pid, _tag, _id }) -> pid
       (_) -> false
     end)


### PR DESCRIPTION
I believe according to the @spec, the method should use Enum.find_value instead of Enum.find in order to return the pid and not the whole tuple.