### PR TITLE
Fix quoted keyword warnings on Elixir 1.7

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -55,15 +55,15 @@ defmodule Cachex.Mixfile do
         tool: ExCoveralls
       ],
       preferred_cli_env: [
-        "docs": :docs,
-        "bench": :bench,
-        "cachex": :test,
-        "coveralls": :test,
+        docs: :docs,
+        bench: :bench,
+        cachex: :test,
+        coveralls: :test,
         "coveralls.html": :test,
         "coveralls.travis": :test
       ],
       aliases: [
-        "bench": "run benchmarks/main.exs"
+        bench: "run benchmarks/main.exs"
       ]
     ]
   end


### PR DESCRIPTION
This fixes:

```
warning: found quoted keyword "docs" but the quotes are not required. Note that keywords are always atoms, even when quoted, and quotes should only be used to introduced keywords with foreign characters in them
  [...]/deps/cachex/mix.exs:58

warning: found quoted keyword "bench" but the quotes are not required. Note that keywords are always atoms, even when quoted, and quotes should only be used to introduced keywords with foreign characters in them
  [...]/deps/cachex/mix.exs:59

warning: found quoted keyword "cachex" but the quotes are not required. Note that keywords are always atoms, even when quoted, and quotes should only be used to introduced keywords with foreign characters in them
  [...]/deps/cachex/mix.exs:60

warning: found quoted keyword "coveralls" but the quotes are not required. Note that keywords are always atoms, even when quoted, and quotes should only be used to introduced keywords with foreign characters in them
  [...]/deps/cachex/mix.exs:61

warning: found quoted keyword "bench" but the quotes are not required. Note that keywords are always atoms, even when quoted, and quotes should only be used to introduced keywords with foreign characters in them
  [...]/deps/cachex/mix.exs:66
```

The warning was introduced in https://github.com/elixir-lang/elixir/pull/7838