### PR TITLE
Updates typespec for Cachex.ttl/3

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -1317,7 +1317,8 @@ defmodule Cachex do
       { :ok, nil }
 
   """
-  @spec ttl(cache, any, Keyword.t) :: { status, number }
+  @spec ttl(cache, any, Keyword.t) :: { status, number |
+  nil}
   def ttl(cache, key, options \\ []) when is_list(options),
     do: Router.call(cache, { :ttl, [ key, options ] })
 


### PR DESCRIPTION
According to the documentation Cachex.ttl/3 can return `{:ok, number()}` or
`{:ok, nil}`. The typespec does not reflect this and can cause dialyzer users
some pain points. This changes the type spec to reflect the actual return
possibilities.

Amos King @adkron <amos@binarynoggin.com>