### PR TITLE
Fix main API & Stats typespecs and provide default values for stats

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -1174,7 +1174,7 @@ defmodule Cachex do
       { :error, :stats_disabled }
 
   """
-  @spec stats(cache, Keyword.t) :: { status, %{ } }
+  @spec stats(cache, Keyword.t) :: { :ok, Cachex.Stats.t() } | { :error, :stats_disabled }
   def stats(cache, options \\ []) when is_list(options),
     do: Router.call(cache, { :stats, [ options ] })
 

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -61,6 +61,8 @@ defmodule Cachex do
   # custom status type
   @type status :: :ok | :error
 
+  @type no_cache :: {:error, :no_cache}
+
   # generate unsafe definitions
   @unsafe [
     clear:             [ 1, 2 ],
@@ -364,7 +366,7 @@ defmodule Cachex do
       { :ok, 0 }
 
   """
-  @spec clear(cache, Keyword.t) :: { status, integer }
+  @spec clear(cache, Keyword.t) :: { :ok, non_neg_integer() } | no_cache()
   def clear(cache, options \\ []) when is_list(options),
     do: Router.call(cache, { :clear, [ options ] })
 
@@ -385,7 +387,7 @@ defmodule Cachex do
       { :ok, 3 }
 
   """
-  @spec count(cache, Keyword.t) :: { status, number }
+  @spec count(cache, Keyword.t) :: { :ok, non_neg_integer() }  | no_cache()
   def count(cache, options \\ []) when is_list(options),
     do: Router.call(cache, { :count, [ options ] })
 
@@ -417,7 +419,7 @@ defmodule Cachex do
       { :ok, -3 }
 
   """
-  @spec decr(cache, any, integer, Keyword.t) :: { status, integer }
+  @spec decr(cache, any, integer, Keyword.t) :: { :ok, integer } | no_cache()
   def decr(cache, key, amount \\ 1, options \\ [])
   when is_integer(amount) and is_list(options) do
     via_opt = via({ :decr, [ key, amount, options ] }, options)
@@ -501,7 +503,7 @@ defmodule Cachex do
       { :ok, true }
 
   """
-  @spec empty?(cache, Keyword.t) :: { status, boolean }
+  @spec empty?(cache, Keyword.t) :: { :ok, boolean } | no_cache()
   def empty?(cache, options \\ []) when is_list(options),
     do: Router.call(cache, { :empty?, [ options ] })
 
@@ -555,7 +557,7 @@ defmodule Cachex do
       { :ok, false }
 
   """
-  @spec exists?(cache, any, Keyword.t) :: { status, boolean }
+  @spec exists?(cache, any, Keyword.t) :: { :ok, boolean } | no_cache()
   def exists?(cache, key, options \\ []) when is_list(options),
     do: Router.call(cache, { :exists?, [ key, options ] })
 
@@ -578,9 +580,9 @@ defmodule Cachex do
       { :ok, false }
 
   """
-  @spec expire(cache, any, number, Keyword.t) :: { status, boolean }
+  @spec expire(cache, any, integer | nil, Keyword.t) :: { :ok, boolean } | no_cache()
   def expire(cache, key, expiration, options \\ [])
-  when (is_nil(expiration) or is_number(expiration)) and is_list(options),
+  when (is_nil(expiration) or is_integer(expiration)) and is_list(options),
     do: Router.call(cache, { :expire, [ key, expiration, options ] })
 
   @doc """
@@ -600,7 +602,7 @@ defmodule Cachex do
       { :ok, false }
 
   """
-  @spec expire_at(cache, binary, number, Keyword.t) :: { status, boolean }
+  @spec expire_at(cache, binary, number, Keyword.t) :: { :ok, boolean } | no_cache()
   def expire_at(cache, key, timestamp, options \\ [])
   when is_number(timestamp) and is_list(options) do
     via_opts = via({ :expire_at, [ key, timestamp, options ] }, options)
@@ -676,7 +678,7 @@ defmodule Cachex do
       { :commit, "yek_gnissim" }
 
   """
-  @spec fetch(cache, any, function, Keyword.t) :: { status | :commit | :ignore, any }
+  @spec fetch(cache, any, function | nil, Keyword.t) :: { status | :commit | :ignore, any } | {:error, :no_cache | :invalid_fallback}
   def fetch(cache, key, fallback \\ nil, options \\ []) when is_list(options) do
     Overseer.enforce(cache) do
       case fallback || fallback(cache(cache, :fallback), :default) do
@@ -701,7 +703,7 @@ defmodule Cachex do
       { :ok, nil }
 
   """
-  @spec get(cache, any, Keyword.t) :: { atom, any }
+  @spec get(cache, any, Keyword.t) :: { :ok, any } | no_cache()
   def get(cache, key, options \\ []) when is_list(options),
     do: Router.call(cache, { :get, [ key, options ] })
 
@@ -729,7 +731,7 @@ defmodule Cachex do
       { :ignore, nil }
 
   """
-  @spec get_and_update(cache, any, function, Keyword.t) :: { :commit | :ignore, any }
+  @spec get_and_update(cache, any, function, Keyword.t) :: { :commit | :ignore, any } | no_cache()
   def get_and_update(cache, key, update_function, options \\ [])
   when is_function(update_function) and is_list(options),
     do: Router.call(cache, { :get_and_update, [ key, update_function, options ] })
@@ -752,7 +754,7 @@ defmodule Cachex do
       { :ok, [] }
 
   """
-  @spec keys(cache, Keyword.t) :: { status, [ any ] }
+  @spec keys(cache, Keyword.t) :: { :ok, [ any ] } | no_cache()
   def keys(cache, options \\ []) when is_list(options),
     do: Router.call(cache, { :keys, [ options ] })
 
@@ -784,7 +786,7 @@ defmodule Cachex do
       { :ok, 7 }
 
   """
-  @spec incr(cache, any, integer, Keyword.t) :: { status, integer }
+  @spec incr(cache, any, integer, Keyword.t) :: { :ok, integer } | no_cache()
   def incr(cache, key, amount \\ 1, options \\ [])
   when is_integer(amount) and is_list(options),
     do: Router.call(cache, { :incr, [ key, amount, options ] })
@@ -885,7 +887,7 @@ defmodule Cachex do
       { :ok, 1328 }
 
   """
-  @spec inspect(cache, atom | tuple, Keyword.t) :: { status, any }
+  @spec inspect(cache, atom | tuple, Keyword.t) :: { :ok, any } | no_cache()
   def inspect(cache, option, options \\ []) when is_list(options),
     do: Router.call(cache, { :inspect, [ option, options ] })
 
@@ -945,7 +947,7 @@ defmodule Cachex do
       { :ok, 1 }
 
   """
-  @spec load(cache, binary, Keyword.t) :: { status, any }
+  @spec load(cache, binary, Keyword.t) :: { :ok, any } | no_cache()
   def load(cache, path, options \\ [])
   when is_binary(path) and is_list(options),
     do: Router.call(cache, { :load, [ path, options ] })
@@ -981,7 +983,7 @@ defmodule Cachex do
       { :ok, 15 }
 
   """
-  @spec purge(cache, Keyword.t) :: { status, number }
+  @spec purge(cache, Keyword.t) :: { :ok, non_neg_integer() } | no_cache()
   def purge(cache, options \\ []) when is_list(options),
     do: Router.call(cache, { :purge, [ options ] })
 
@@ -1010,7 +1012,7 @@ defmodule Cachex do
 
   """
   # TODO: maybe rename TTL to be expiration?
-  @spec put(cache, any, any, Keyword.t) :: { status, boolean }
+  @spec put(cache, any, any, Keyword.t) :: { :ok, boolean | non_neg_integer() } | no_cache()
   def put(cache, key, value, options \\ []) when is_list(options),
     do: Router.call(cache, { :put, [ key, value, options ] })
 
@@ -1041,7 +1043,7 @@ defmodule Cachex do
 
   """
   # TODO: maybe rename TTL to be expiration?
-  @spec put_many(cache, [ { any, any } ], Keyword.t) :: { status, boolean }
+  @spec put_many(cache, [ { any, any } ], Keyword.t) :: { :ok, boolean | non_neg_integer() } | no_cache()
   def put_many(cache, pairs, options \\ [])
   when is_list(pairs) and is_list(options),
     do: Router.call(cache, { :put_many, [ pairs, options ] })
@@ -1069,7 +1071,7 @@ defmodule Cachex do
       { :ok, false }
 
   """
-  @spec refresh(cache, any, Keyword.t) :: { status, boolean }
+  @spec refresh(cache, any, Keyword.t) :: { :ok, boolean | non_neg_integer() } | no_cache()
   def refresh(cache, key, options \\ []) when is_list(options),
     do: Router.call(cache, { :refresh, [ key, options ] })
 
@@ -1111,7 +1113,7 @@ defmodule Cachex do
       { :ok, true }
 
   """
-  @spec reset(cache, Keyword.t) :: { status, true }
+  @spec reset(cache, Keyword.t) :: { :ok, true } | no_cache()
   def reset(cache, options \\ []) when is_list(options),
     do: Router.call(cache, { :reset, [ options ] })
 
@@ -1148,7 +1150,7 @@ defmodule Cachex do
       { :ok, 3 }
 
   """
-  @spec size(cache, Keyword.t) :: { status, number }
+  @spec size(cache, Keyword.t) :: { :ok, non_neg_integer() } | no_cache()
   def size(cache, options \\ []) when is_list(options),
     do: Router.call(cache, { :size, [ options ] })
 
@@ -1174,7 +1176,7 @@ defmodule Cachex do
       { :error, :stats_disabled }
 
   """
-  @spec stats(cache, Keyword.t) :: { :ok, Cachex.Stats.t() } | { :error, :stats_disabled }
+  @spec stats(cache, Keyword.t) :: { :ok, Cachex.Stats.t() } | { :error, :stats_disabled | :no_cache }
   def stats(cache, options \\ []) when is_list(options),
     do: Router.call(cache, { :stats, [ options ] })
 
@@ -1221,7 +1223,7 @@ defmodule Cachex do
       [{"b", 2}, {"c", 3}, {"a", 1}]
 
   """
-  @spec stream(cache, any, Keyword.t) :: { status, Enumerable.t }
+  @spec stream(cache, any, Keyword.t) :: { :ok, Enumerable.t } | no_cache()
   def stream(cache, query \\ Query.create(true), options \\ [])
   when is_list(options),
     do: Router.call(cache, { :stream, [ query, options ] })
@@ -1245,7 +1247,7 @@ defmodule Cachex do
       { :ok, nil }
 
   """
-  @spec take(cache, any, Keyword.t) :: { status, any }
+  @spec take(cache, any, Keyword.t) :: { :ok, any } | no_cache()
   def take(cache, key, options \\ []) when is_list(options),
     do: Router.call(cache, { :take, [ key, options ] })
 
@@ -1255,7 +1257,7 @@ defmodule Cachex do
   This is very similar to `refresh/3` except that the expiration
   time is maintained inside the record (using a calculated offset).
   """
-  @spec touch(cache, any, Keyword.t) :: { status, boolean }
+  @spec touch(cache, any, Keyword.t) :: { :ok, boolean } | no_cache()
   def touch(cache, key, options \\ []) when is_list(options),
     do: Router.call(cache, { :touch, [ key, options ] })
 
@@ -1281,7 +1283,7 @@ defmodule Cachex do
       { :ok, [ "value1", "value2" ] }
 
   """
-  @spec transaction(cache, [ any ], function, Keyword.t) :: { status, any }
+  @spec transaction(cache, [ any ], function, Keyword.t) :: { :ok, any } | no_cache()
   def transaction(cache, keys, operation, options \\ [])
   when is_function(operation, 1) and is_list(keys) and is_list(options) do
     Overseer.enforce(cache) do
@@ -1317,8 +1319,7 @@ defmodule Cachex do
       { :ok, nil }
 
   """
-  @spec ttl(cache, any, Keyword.t) :: { status, number |
-  nil}
+  @spec ttl(cache, any, Keyword.t) :: { :ok, integer() | nil } | no_cache()
   def ttl(cache, key, options \\ []) when is_list(options),
     do: Router.call(cache, { :ttl, [ key, options ] })
 
@@ -1344,7 +1345,7 @@ defmodule Cachex do
       { :ok, false }
 
   """
-  @spec update(cache, any, any, Keyword.t) :: { status, any }
+  @spec update(cache, any, any, Keyword.t) :: { :ok, any } | no_cache()
   def update(cache, key, value, options \\ []) when is_list(options),
     do: Router.call(cache, { :update, [ key, value, options ] })
 

--- a/lib/cachex/actions/stats.ex
+++ b/lib/cachex/actions/stats.ex
@@ -20,7 +20,7 @@ defmodule Cachex.Actions.Stats do
 
   If the provided cache does not have statistics enabled, an error will be returned.
   """
-  @spec execute(Spec.cache, Keyword.t) :: { :ok, %{ } } | { :error, :stats_disabled }
+  @spec execute(Spec.cache, Keyword.t) :: { :ok, Stats.t() } | { :error, :stats_disabled }
   def execute(cache() = cache, _options) do
     with { :ok, stats } <- Stats.retrieve(cache) do
       hits_count = Map.get(stats,   :hits, 0)

--- a/lib/cachex/actions/stats.ex
+++ b/lib/cachex/actions/stats.ex
@@ -46,24 +46,18 @@ defmodule Cachex.Actions.Stats do
   # This will generate hit/miss rates as floats, even when they're integer
   # values to ensure consistency. This is separated out to easily handle the
   # potential to divide values by 0, avoiding a crash in the application.
-  defp generate_rates(_reqs, 0, misses),
+  defp generate_rates(_reqs, 0, _misses),
     do: %{
-      hits: 0,
-      misses: misses,
       hit_rate: 0.0,
       miss_rate: 100.0
     }
-  defp generate_rates(_reqs, hits, 0),
+  defp generate_rates(_reqs, _hits, 0),
     do: %{
-      hits: hits,
-      misses: 0,
       hit_rate: 100.0,
       miss_rate: 0.0
     }
   defp generate_rates(reqs, hits, misses),
     do: %{
-      hits: hits,
-      misses: misses,
       hit_rate: (hits / reqs) * 100,
       miss_rate: (misses / reqs) * 100
     }

--- a/lib/cachex/stats.ex
+++ b/lib/cachex/stats.ex
@@ -30,18 +30,18 @@ defmodule Cachex.Stats do
   ]
 
   @type t() :: %{
-    calls: %{required(atom) => pos_integer()},
-    evictions: pos_integer(),
-    expirations: pos_integer(),
+    calls: %{required(atom) => non_neg_integer()},
+    evictions: non_neg_integer(),
+    expirations: non_neg_integer(),
     hit_rate: float(),
-    hits: pos_integer(),
-    invocations: %{required(atom) => pos_integer()},
+    hits: non_neg_integer(),
+    invocations: %{required(atom) => non_neg_integer()},
     meta: meta(),
     miss_rate: float(),
-    misses: pos_integer(),
-    operations: %{required(atom) => pos_integer()},
-    updates: pos_integer(),
-    writes: pos_integer()
+    misses: non_neg_integer(),
+    operations: %{required(atom) => non_neg_integer()},
+    updates: non_neg_integer(),
+    writes: non_neg_integer()
   }
 
   @type meta() :: %{

--- a/lib/cachex/stats.ex
+++ b/lib/cachex/stats.ex
@@ -29,6 +29,25 @@ defmodule Cachex.Stats do
     :update
   ]
 
+  @type t() :: %{
+    calls: %{required(atom) => pos_integer()},
+    evictions: pos_integer(),
+    expirations: pos_integer(),
+    hit_rate: float(),
+    hits: pos_integer(),
+    invocations: %{required(atom) => pos_integer()},
+    meta: meta(),
+    miss_rate: float(),
+    misses: pos_integer(),
+    operations: %{required(atom) => pos_integer()},
+    updates: pos_integer(),
+    writes: pos_integer()
+  }
+
+  @type meta() :: %{
+    creation_date: pos_integer()
+  }
+
   ##############
   # Public API #
   ##############
@@ -50,7 +69,7 @@ defmodule Cachex.Stats do
   @doc """
   Retrieves the latest statistics for a cache.
   """
-  @spec retrieve(Spec.cache) :: %{ }
+  @spec retrieve(Spec.cache) :: {:ok, t()} | {:error, :stats_disabled}
   def retrieve(cache(name: name) = cache) do
     case enabled?(cache) do
       false -> error(:stats_disabled)
@@ -71,8 +90,21 @@ defmodule Cachex.Stats do
   # The `:creationDate` field is set inside the `:meta` field to contain the date
   # at which the statistics container was first created (which is more of less
   # equivalent to the start time of the cache).
-  def init(_options),
-    do: { :ok, %{ meta: %{ creation_date: now() } } }
+  def init(_options) do
+    initial_state = %{
+      evictions: 0,
+      expirations: 0,
+      hits: 0,
+      misses: 0,
+      operations: 0,
+      updates: 0,
+      writes: 0,
+      meta: %{ creation_date: now() },
+      calls: %{ }
+    }
+
+    {:ok, initial_state}
+  end
 
   @doc false
   # Retrieves the current stats container.

--- a/test/cachex/actions/stats_test.exs
+++ b/test/cachex/actions/stats_test.exs
@@ -76,10 +76,10 @@ defmodule Cachex.Actions.StatsTest do
     stats4 = Cachex.stats!(cache4)
 
     # remove the metadata from the stats
-    stats1 = Map.delete(stats1, :meta)
-    stats2 = Map.delete(stats2, :meta)
-    stats3 = Map.delete(stats3, :meta)
-    stats4 = Map.delete(stats4, :meta)
+    _stats1 = Map.delete(stats1, :meta)
+    _stats2 = Map.delete(stats2, :meta)
+    _stats3 = Map.delete(stats3, :meta)
+    _stats4 = Map.delete(stats4, :meta)
 
     # verify a 100% miss rate for cache1
     assert(stats1 == %{

--- a/test/cachex/actions/stats_test.exs
+++ b/test/cachex/actions/stats_test.exs
@@ -70,16 +70,10 @@ defmodule Cachex.Actions.StatsTest do
     { :commit, 1 } = Cachex.fetch(cache4, 1, &(&1))
 
     # retrieve all cache rates
-    stats1 = Cachex.stats!(cache1)
-    stats2 = Cachex.stats!(cache2)
-    stats3 = Cachex.stats!(cache3)
-    stats4 = Cachex.stats!(cache4)
-
-    # remove the metadata from the stats
-    _stats1 = Map.delete(stats1, :meta)
-    _stats2 = Map.delete(stats2, :meta)
-    _stats3 = Map.delete(stats3, :meta)
-    _stats4 = Map.delete(stats4, :meta)
+    stats1 = stats_no_meta(cache1)
+    stats2 = stats_no_meta(cache2)
+    stats3 = stats_no_meta(cache3)
+    stats4 = stats_no_meta(cache4)
 
     # verify a 100% miss rate for cache1
     assert(stats1 == %{
@@ -181,5 +175,12 @@ defmodule Cachex.Actions.StatsTest do
     assert(stats2.calls.put == 2)
     assert(stats2.operations == 5)
     assert(stats2.hit_rate == 50.0)
+  end
+
+  # Retrieves stats with no :meta field
+  defp stats_no_meta(cache) do
+    with { :ok, stats } <- Cachex.stats(cache) do
+      Map.delete(stats, :meta)
+    end
   end
 end

--- a/test/cachex/actions/stats_test.exs
+++ b/test/cachex/actions/stats_test.exs
@@ -90,7 +90,11 @@ defmodule Cachex.Actions.StatsTest do
       operations: 1,
       calls: %{
         get: 1
-      }
+      },
+      evictions: 0,
+      expirations: 0,
+      writes: 0,
+      updates: 0
     })
 
     # verify a 100% hit rate for cache2
@@ -104,7 +108,10 @@ defmodule Cachex.Actions.StatsTest do
       calls: %{
         get: 1,
         put: 1
-      }
+      },
+      evictions: 0,
+      expirations: 0,
+      updates: 0
     })
 
     # verify a 50% hit rate for cache3
@@ -118,7 +125,10 @@ defmodule Cachex.Actions.StatsTest do
       calls: %{
         get: 2,
         put: 1
-      }
+      },
+      evictions: 0,
+      expirations: 0,
+      updates: 0
     })
 
     # verify a load count for cache4
@@ -132,7 +142,10 @@ defmodule Cachex.Actions.StatsTest do
       writes: 1,
       calls: %{
         fetch: 1
-      }
+      },
+      evictions: 0,
+      expirations: 0,
+      updates: 0
     })
   end
 

--- a/test/cachex/stats_test.exs
+++ b/test/cachex/stats_test.exs
@@ -432,8 +432,9 @@ defmodule Cachex.StatsTest do
   # module, so please refer to those tests for any issues with counters.
   test "retrieving the state of a stats hook" do
     # create a test cache
-    cache = Helper.create_cache([ stats: true ])
-    cache = Services.Overseer.retrieve(cache)
+    cache =
+      Helper.create_cache([ stats: true ])
+      |> Services.Overseer.retrieve()
 
     # retrieve the current time
     ctime = now()

--- a/test/cachex/stats_test.exs
+++ b/test/cachex/stats_test.exs
@@ -29,7 +29,11 @@ defmodule Cachex.StatsTest do
       calls: %{
         clear: 1,
         put: 5
-      }
+      },
+      expirations: 0,
+      hits: 0,
+      misses: 0,
+      updates: 0
     })
   end
 
@@ -60,7 +64,11 @@ defmodule Cachex.StatsTest do
       calls: %{
         del: 2,
         put: 2
-      }
+      },
+      expirations: 0,
+      hits: 0,
+      misses: 0,
+      updates: 0
     })
   end
 
@@ -92,7 +100,10 @@ defmodule Cachex.StatsTest do
       calls: %{
         exists?: 2,
         put: 1
-      }
+      },
+      evictions: 0,
+      expirations: 0,
+      updates: 0
     })
   end
 
@@ -123,7 +134,10 @@ defmodule Cachex.StatsTest do
       calls: %{
         get: 2,
         put: 1
-      }
+      },
+      evictions: 0,
+      expirations: 0,
+      updates: 0
     })
   end
 
@@ -157,7 +171,10 @@ defmodule Cachex.StatsTest do
       calls: %{
         fetch: 3,
         put: 1
-      }
+      },
+      evictions: 0,
+      expirations: 0,
+      updates: 0
     })
   end
 
@@ -188,7 +205,11 @@ defmodule Cachex.StatsTest do
       calls: %{
         incr: 2,
         decr: 2
-      }
+      },
+      evictions: 0,
+      expirations: 0,
+      hits: 0,
+      misses: 0
     })
   end
 
@@ -239,7 +260,9 @@ defmodule Cachex.StatsTest do
         invoke: 2,
         put: 1,
         update: 1
-      }
+      },
+      evictions: 0,
+      expirations: 0
     })
   end
 
@@ -273,7 +296,10 @@ defmodule Cachex.StatsTest do
       calls: %{
         purge: 1,
         put: 5
-      }
+      },
+      hits: 0,
+      misses: 0,
+      updates: 0
     })
   end
 
@@ -298,7 +324,12 @@ defmodule Cachex.StatsTest do
       writes: 5,
       calls: %{
         put: 5
-      }
+      },
+      evictions: 0,
+      expirations: 0,
+      hits: 0,
+      misses: 0,
+      updates: 0
     })
   end
 
@@ -322,7 +353,12 @@ defmodule Cachex.StatsTest do
       writes: 5,
       calls: %{
         put_many: 1
-      }
+      },
+      evictions: 0,
+      expirations: 0,
+      hits: 0,
+      misses: 0,
+      updates: 0
     })
   end
 
@@ -356,7 +392,9 @@ defmodule Cachex.StatsTest do
       calls: %{
         put: 1,
         take: 2
-      }
+      },
+      expirations: 0,
+      updates: 0
     })
   end
 
@@ -380,7 +418,11 @@ defmodule Cachex.StatsTest do
       calls: %{
         put: 1,
         touch: 1
-      }
+      },
+      evictions: 0,
+      expirations: 0,
+      hits: 0,
+      misses: 0
     })
   end
 


### PR DESCRIPTION
The typespecs for stats currently do not match the return values and cause dialyzer errors for users. To update and keep the typespec accurate, default values for the stats properties should be present as this is the most common use case. Specs for all the main API functions not related to distributed or dump/load functionality have been updated to accurately reflect possible return values.

I would advocate for moving hit/miss rates to the gen_server retrieve as I do not see any risk to calculating when retrieving since the divide by zero cases are covered and this would centralize all of the stats. I did not move it at this time but would be happy to as part of this PR.

There are a few small code cleanups, as well.