### PR TITLE
Documentation typo

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -620,7 +620,7 @@ defmodule Cachex do
    ## Examples
 
       iex> Cachex.put(:my_cache, "key", "value")
-      iex> Cachex.list(:my_cache)
+      iex> Cachex.export(:my_cache)
       { :ok, [ { :entry, "key", 1538714590095, nil, "value" } ] }
 
   """


### PR DESCRIPTION
Fixes a small documentation typo `Cachex.list` -> `Cachex.export`