### PR TITLE
Restructure internal APIs to expose import/3

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -77,6 +77,7 @@ defmodule Cachex do
     fetch:          [ 2, 3, 4 ],
     get:               [ 2, 3 ],
     get_and_update:    [ 3, 4 ],
+    import:            [ 2, 3 ],
     incr:           [ 2, 3, 4 ],
     inspect:           [ 2, 3 ],
     invoke:            [ 3, 4 ],
@@ -755,6 +756,24 @@ defmodule Cachex do
   @spec keys(cache, Keyword.t) :: { status, [ any ] }
   def keys(cache, options \\ []) when is_list(options),
     do: Router.call(cache, { :keys, [ options ] })
+
+  @doc """
+  Imports an export set into a cache.
+
+  This provides a raw import of a previously exported cache via the use
+  of the `export/2` command.
+
+   ## Examples
+
+      iex> Cachex.put(:my_cache, "key", "value")
+      iex> Cachex.import(:my_cache, [ { :entry, "key", 1538714590095, nil, "value" } ])
+      { :ok, true }
+
+  """
+  @spec import(cache, [ Spec.entry ], Keyword.t) :: { status, [ cache ] }
+  def import(cache, entries, options \\ [])
+  when is_list(entries) and is_list(options),
+    do: Router.call(cache, { :import, [ entries, options ] })
 
   @doc """
   Increments an entry in the cache.

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -625,7 +625,7 @@ defmodule Cachex do
       { :ok, [ { :entry, "key", 1538714590095, nil, "value" } ] }
 
   """
-  @spec export(cache, Keyword.t) :: { status, [ cache ] }
+  @spec export(cache, Keyword.t) :: { status, [ Spec.entry ] }
   def export(cache, options \\ []) when is_list(options),
     do: Router.call(cache, { :export, [ options ] })
 
@@ -770,7 +770,7 @@ defmodule Cachex do
       { :ok, true }
 
   """
-  @spec import(cache, [ Spec.entry ], Keyword.t) :: { status, [ cache ] }
+  @spec import(cache, [ Spec.entry ], Keyword.t) :: { status, any }
   def import(cache, entries, options \\ [])
   when is_list(entries) and is_list(options),
     do: Router.call(cache, { :import, [ entries, options ] })

--- a/lib/cachex/actions/import.ex
+++ b/lib/cachex/actions/import.ex
@@ -1,0 +1,51 @@
+defmodule Cachex.Actions.Import do
+  @moduledoc false
+  # Command module to allow import cache entries from a list.
+  #
+  # This command should be considered expensive and should be use sparingly. Due
+  # to the requirement of being compatible with distributed caches, this cannot
+  # use a simple `put_many/4` call; rather it needs to walk the full list. It's
+  # provided because it's the backing implementation of the `load/3` command.
+  import Cachex.Spec
+
+  ##############
+  # Public API #
+  ##############
+
+  @doc """
+  Imports all cache entries from a list into a cache.
+
+  This action should only be used in the case of exports and/or debugging, due
+  to the memory overhead involved, as well as the potential slowness of walking
+  a large import set.
+  """
+  def execute(cache() = cache, entries, _options),
+    do: { Enum.each(entries, &import(cache, &1, now())), true }
+
+  # Imports an entry directly when no TTL is included.
+  #
+  # As this is a direct import, we just use `Cachex.put/4` with the provided
+  # key and value from the existing entry record - nothing special here.
+  defp import(cache, entry(key: k, ttl: nil, value: v), _time),
+    do: { :ok, true } = Cachex.put(cache, k, v, const(:notify_false))
+
+  # Skips over entries which have already expired.
+  #
+  # This occurs in the case there was an existing touch time and TTL, and
+  # the expiration time would already have passed (so there's no point in
+  # adding the record to the cache just to throw it away in future).
+  defp import(_cache, entry(touched: t1, ttl: t2), time)
+  when t1 + t2 < time,
+    do: nil
+
+  # Imports an entry, using the current time to offset the TTL value.
+  #
+  # This is required to shift the TTLs set in a backup to match the current
+  # import time, so that the rest of the lifetime of the key is the same. If
+  # we didn't do this, the key would live longer in the cache than intended.
+  defp import(cache, entry(key: k, touched: t1, ttl: t2, value: v), time) do
+    { :ok, true } = Cachex.put(cache, k, v, const(:notify_false) ++ [
+      ttl: (t1 + t2) - time
+    ])
+  end
+end

--- a/lib/cachex/actions/load.ex
+++ b/lib/cachex/actions/load.ex
@@ -27,34 +27,11 @@ defmodule Cachex.Actions.Load do
   """
   def execute(cache() = cache, path, options) do
     with { :ok, entries } <- Disk.read(path, options) do
-      { Enum.each(entries, &import(cache, &1, now())), true }
+      iopts =
+        options
+        |> Keyword.take([ :local ])
+        |> Enum.concat(const(:notify_false))
+      Cachex.import(cache, entries, iopts)
     end
-  end
-
-  # Imports an entry directly when no TTL is included.
-  #
-  # As this is a direct import, we just use `Cachex.put/4` with the provided
-  # key and value from the existing entry record - nothing special here.
-  defp import(cache, entry(key: k, ttl: nil, value: v), _time),
-    do: { :ok, true } = Cachex.put(cache, k, v, const(:notify_false))
-
-  # Skips over entries which have already expired.
-  #
-  # This occurs in the case there was an existing touch time and TTL, and
-  # the expiration time would already have passed (so there's no point in
-  # adding the record to the cache just to throw it away in future).
-  defp import(_cache, entry(touched: t1, ttl: t2), time)
-  when t1 + t2 < time,
-    do: nil
-
-  # Imports an entry, using the current time to offset the TTL value.
-  #
-  # This is required to shift the TTLs set in a backup to match the current
-  # import time, so that the rest of the lifetime of the key is the same. If
-  # we didn't do this, the key would live longer in the cache than intended.
-  defp import(cache, entry(key: k, touched: t1, ttl: t2, value: v), time) do
-    { :ok, true } = Cachex.put(cache, k, v, const(:notify_false) ++ [
-      ttl: (t1 + t2) - time
-    ])
   end
 end

--- a/lib/cachex/router.ex
+++ b/lib/cachex/router.ex
@@ -156,9 +156,9 @@ defmodule Cachex.Router do
 
   # actions which merge outputs
   @merge_actions [
-    :clear, :count, :empty?,  :export,
-    :keys,  :purge, :reset,   :size,
-    :stats
+    :clear,  :count, :empty?, :export,
+    :import, :keys,  :purge,  :reset,
+    :size,   :stats
   ]
 
   # Provides handling of cross-node actions distributed over remote nodes.

--- a/test/cachex/actions/import_test.exs
+++ b/test/cachex/actions/import_test.exs
@@ -1,0 +1,41 @@
+defmodule Cachex.Actions.ImportTest do
+  use CachexCase
+
+  # This test verifies that it's possible to import entries into a cache.
+  # As it stands, this is a barebones test to ensure the length of the
+  # import as it's covered more heavily by the test cases based on `load/2`.
+  test "importing records into a cache" do
+    # create a test cache
+    cache = Helper.create_cache()
+    start = now()
+
+    # add some cache entries
+    { :ok, true } = Cachex.put(cache, 1, 1)
+    { :ok, true } = Cachex.put(cache, 2, 2, [ ttl: 1 ])
+    { :ok, true } = Cachex.put(cache, 3, 3, [ ttl: 10_000 ])
+
+    # export the cache to a list
+    result1 = Cachex.export(cache)
+    result2 = Cachex.clear(cache)
+    result3 = Cachex.size(cache)
+
+    # verify the clearance
+    assert(result2 == { :ok, 3 })
+    assert(result3 == { :ok, 0 })
+
+    # wait a while before re-load
+    :timer.sleep(50)
+
+    # load the cache from the export
+    result4 = Cachex.import(cache, elem(result1, 1))
+    result5 = Cachex.size(cache)
+    result6 = Cachex.ttl!(cache, 3)
+
+    # verify that the import was ok
+    assert(result4 == { :ok, true })
+    assert(result5 == { :ok, 2 })
+
+    # verify TTL offsetting happens
+    assert_in_delta(result6, 10_000 - (now() - start), 5)
+  end
+end

--- a/test/cachex/actions/load_test.exs
+++ b/test/cachex/actions/load_test.exs
@@ -52,5 +52,4 @@ defmodule Cachex.Actions.LoadTest do
     # verify the result failed
     assert(result7 == { :error, :unreachable_file })
   end
-
 end

--- a/test/cachex_test.exs
+++ b/test/cachex_test.exs
@@ -177,7 +177,7 @@ defmodule CachexTest do
     assert(is_even(length(definitions)))
 
     # verify the size to cause errors on addition/removal
-    assert(length(definitions) == 148)
+    assert(length(definitions) == 152)
 
     # validate all definitions
     for { name, arity } <- definitions do


### PR DESCRIPTION
This fixes #208.

The changes are fairly straightforward; this just moves the import code from `load/3` over to a custom function named `import/3` which can be used to import a list of entries.