### PR TITLE
Cachex.execute simply returns the value that your function returns

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -69,7 +69,6 @@ defmodule Cachex do
     del:               [ 2, 3 ],
     dump:              [ 2, 3 ],
     empty?:            [ 1, 2 ],
-    execute:           [ 2, 3 ],
     exists?:           [ 2, 3 ],
     expire:            [ 3, 4 ],
     expire_at:         [ 3, 4 ],
@@ -529,10 +528,10 @@ defmodule Cachex do
       ...>   val2 = Cachex.get!(worker, "key2")
       ...>   [val1, val2]
       ...> end)
-      { :ok, [ "value1", "value2" ] }
+      [ "value1", "value2" ]
 
   """
-  @spec execute(cache, function, Keyword.t) :: { status, any }
+  @spec execute(cache, function, Keyword.t) :: {:error, :no_cache} | any
   def execute(cache, operation, options \\ [])
   when is_function(operation, 1) and is_list(options) do
     Overseer.enforce(cache) do

--- a/test/cachex_test.exs
+++ b/test/cachex_test.exs
@@ -177,10 +177,10 @@ defmodule CachexTest do
     assert(is_even(length(definitions)))
 
     # verify the size to cause errors on addition/removal
-    assert(length(definitions) == 152)
+    assert(length(definitions) == 150)
 
     # validate all definitions
-    for { name, arity } <- definitions do
+    for { name, arity } <- definitions, name != :execute do
       # create name as string
       name_st = "#{name}"
 


### PR DESCRIPTION
Update typespec and doc example
Remove `Cachex.execute!` auto-generated function as well

Fixes #216 