### PR TITLE
Fix for mix release missing jumper

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -75,7 +75,7 @@ defmodule Cachex.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [
-      applications: [:logger, :eternal, :sleeplocks],
+      applications: [:logger, :eternal, :sleeplocks, :jumper],
       mod: {Cachex.Application, []}
     ]
   end


### PR DESCRIPTION
Cachex as it stands, if you do a mix release, will not include the jumper module which causes cache operations to fail with a missing module. 

On our application side we fix it by adding jumper to extra_applications but the proper fix is to add it to applications.

The ideal fix would be to add things to extra_applications instead as applications is clobbering anything added by deps. But this is the minimum viable fix I believe.