### PR TITLE
Add nil option to expiration specs and switch it to non_neg_int

### DIFF
--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -53,8 +53,8 @@ defmodule Cachex.Spec do
 
   # Record specification for a cache expiration
   @type expiration :: record(:expiration,
-    default: integer,
-    interval: integer,
+    default: non_neg_integer,
+    interval: non_neg_integer | nil,
     lazy: boolean
   )
 


### PR DESCRIPTION
In the docs we can read:
> A default value can be provided which will then be added as a default TTL
> to all keys which do not have one set explicitly. This must be a valid millisecond integer.

> The interval being controlled here is the Janitor service schedule;
> it controls how often the purge runs in the background of your application
> to remove expired records.
> This can be disabled completely by setting the value to nil. This is also a millisecond integer.

However, regarding specs, the field interval wasn't nilable. This PR
fixes that. It also changes both default and interval to only allows
non_neg integers, since only they can be appropriately interpreted as
intervals.