### PR TITLE
Remove TTL mentioning from incr&decr description

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -405,8 +405,7 @@ defmodule Cachex do
   @doc """
   Decrements an entry in the cache.
 
-  This will overwrite any value that was previously set against the provided key,
-  and overwrite any TTLs which were already set.
+  This will overwrite any value that was previously set against the provided key.
 
   ## Options
 
@@ -790,8 +789,7 @@ defmodule Cachex do
   @doc """
   Increments an entry in the cache.
 
-  This will overwrite any value that was previously set against the provided key,
-  and overwrite any TTLs which were already set.
+  This will overwrite any value that was previously set against the provided key.
 
   ## Options
 


### PR DESCRIPTION
There seems to be a copy&paste issue in the description of `incr/4` and `decr/4` which led to some confusion while working with the lib. As far as I understand both functions do not allow to use the `:ttl` option and thus should not mentioned TTL overwriting in the description.