### PR TITLE
warmer macro dialyzer fix

### DIFF
--- a/lib/cachex/warmer.ex
+++ b/lib/cachex/warmer.ex
@@ -52,7 +52,7 @@ defmodule Cachex.Warmer do
 
   @doc false
   defmacro __using__(_) do
-    quote location: :keep do
+    quote location: :keep, generated: true do
       use GenServer
 
       # enforce the behaviour


### PR DESCRIPTION
i'm getting dialyzer errors with generated code in `Cachex.Warmer` `__using__` macro:

```
lib/cachex/warmer.ex:81:pattern_match
The pattern can never match the type.

Pattern:
:ignore

Type:
{:ok, [any(), ...]}
________________________________________________________________________________
lib/cachex/warmer.ex:89:pattern_match
The pattern can never match the type.

Pattern:
{:ok, _, _}

Type:
{:ok, [any(), ...]}
```

i assume this is because in reality i return `{:ok, [..]}`from `execute` and dialyzer has grown smarter and sees compile time that these two other cases will not ever hit.