### PR TITLE
Add failing test for ttl opt for fetch

### DIFF
--- a/test/cachex/actions/fetch_test.exs
+++ b/test/cachex/actions/fetch_test.exs
@@ -94,6 +94,23 @@ defmodule Cachex.Actions.FetchTest do
     # both should be an error for invalid function
     assert(result8 == { :error, :invalid_fallback })
     assert(result9 == { :error, :invalid_fallback })
+
+    # check using ttl
+    result10 = Cachex.fetch(cache1, "key9", fb_opt2, ttl: 1)
+    result11 = Cachex.fetch(cache1, "key10", fb_opt2, ttl: :timer.seconds(10))
+
+    assert(result10 == { :commit, "9yek" })
+    assert(result11 == { :commit, "01yek" })
+
+    # wait for the TTL to pass
+    :timer.sleep(2)
+
+    result12 = Cachex.fetch(cache1, "key9", fn -> "used" end)
+    result13 = Cachex.fetch(cache1, "key10", fn -> "not used" end)
+
+    # Currently fails because the ttl isn't respected so the original key9 value has not expired and so isn't replaced with 'used'
+    assert(result12 == { :ok, "used" })
+    assert(result13 == { :ok, "01yek" })
   end
 
   # This test ensures that the fallback is executed just once when a


### PR DESCRIPTION
Hi, I've added this test in order to try to illustrate my thoughts on how the API was going to work. I can understand if there are reasons why it shouldn't work that way but for my use case and my level of understanding, it would be a really useful addition.

I'm afraid I would not be confident in trying change things so that this test passed and I'm not sure if that would be desirable anyway.

Please close this PR if this isn't a reasonably direction to go in.

Aimed at helping: #253 

---

The 'ttl: 1' is not respected and so the entry doesn't expire so we
don't get the "used" value back from the fallback on the fetch.

The assert on key10 works but because the ttl isn't set rather than
because the ttl is long enough that it shouldn't have expired.