### PR TITLE
Add note about using 'ttl' on fetch

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -676,6 +676,12 @@ defmodule Cachex do
   in the `:fallback` option at cache startup, the third argument to
   this call becomes optional.
 
+  ## Options
+
+  Although this function can put an entry into a cache, it does not
+  and cannot handle a `ttl` option. See
+  [here](ttl-implementation.html#key-expirations) for more details.
+
   ## Examples
 
       iex> Cachex.put(:my_cache, "key", "value")


### PR DESCRIPTION
Adding a note that would have helped me. I realise in a ideal world one would read all the documentation for a project before trying to use it. However I feel like it can be useful to add these kind of cross-references.

Feel free to close without merging. I just wanted to try to contribute.

I'm not 100% sure that the link will work but I think it might based off this example:

  https://github.com/phoenixframework/phoenix/blob/v1.5.4/lib/phoenix.ex#L29
  https://hexdocs.pm/phoenix/Phoenix.html#content 

---

It seems that perhaps it has come up before as there is already
documentation about it in the guides. This helps people to find that
documentation more easily.