### PR TITLE
Remove unnecessary html line breaks in docs

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -53,52 +53,52 @@ defmodule Cachex do
   require Router
 
   # avoid inspect clashes
-  import Kernel, except: [ inspect: 2 ]
+  import Kernel, except: [inspect: 2]
 
   # the cache type
-  @type cache :: atom | Spec.cache
+  @type cache :: atom | Spec.cache()
 
   # custom status type
   @type status :: :ok | :error
 
   # generate unsafe definitions
   @unsafe [
-    clear:             [ 1, 2 ],
-    count:             [ 1, 2 ],
-    decr:           [ 2, 3, 4 ],
-    del:               [ 2, 3 ],
-    dump:              [ 2, 3 ],
-    empty?:            [ 1, 2 ],
-    execute:           [ 2, 3 ],
-    exists?:           [ 2, 3 ],
-    expire:            [ 3, 4 ],
-    expire_at:         [ 3, 4 ],
-    export:            [ 1, 2 ],
-    fetch:          [ 2, 3, 4 ],
-    get:               [ 2, 3 ],
-    get_and_update:    [ 3, 4 ],
-    import:            [ 2, 3 ],
-    incr:           [ 2, 3, 4 ],
-    inspect:           [ 2, 3 ],
-    invoke:            [ 3, 4 ],
-    keys:              [ 1, 2 ],
-    load:              [ 2, 3 ],
-    persist:           [ 2, 3 ],
-    purge:             [ 1, 2 ],
-    put:               [ 3, 4 ],
-    put_many:          [ 2, 3 ],
-    refresh:           [ 2, 3 ],
-    reset:             [ 1, 2 ],
-    set:               [ 3, 4 ],
-    set_many:          [ 2, 3 ],
-    size:              [ 1, 2 ],
-    stats:             [ 1, 2 ],
-    stream:         [ 1, 2, 3 ],
-    take:              [ 2, 3 ],
-    touch:             [ 2, 3 ],
-    transaction:       [ 3, 4 ],
-    ttl:               [ 2, 3 ],
-    update:            [ 3, 4 ]
+    clear: [1, 2],
+    count: [1, 2],
+    decr: [2, 3, 4],
+    del: [2, 3],
+    dump: [2, 3],
+    empty?: [1, 2],
+    execute: [2, 3],
+    exists?: [2, 3],
+    expire: [3, 4],
+    expire_at: [3, 4],
+    export: [1, 2],
+    fetch: [2, 3, 4],
+    get: [2, 3],
+    get_and_update: [3, 4],
+    import: [2, 3],
+    incr: [2, 3, 4],
+    inspect: [2, 3],
+    invoke: [3, 4],
+    keys: [1, 2],
+    load: [2, 3],
+    persist: [2, 3],
+    purge: [1, 2],
+    put: [3, 4],
+    put_many: [2, 3],
+    refresh: [2, 3],
+    reset: [1, 2],
+    set: [3, 4],
+    set_many: [2, 3],
+    size: [1, 2],
+    stats: [1, 2],
+    stream: [1, 2, 3],
+    take: [2, 3],
+    touch: [2, 3],
+    transaction: [3, 4],
+    ttl: [2, 3],
+    update: [3, 4]
   ]
 
   ##############
@@ -119,15 +119,12 @@ defmodule Cachex do
 
     * `:commands`
 
-      </br>
       This option allows you to attach a set of custom commands to a cache in
       order to provide shorthand execution. A cache command must be constructed
       using the `:command` record provided by `Cachex.Spec`.
 
-      </br>
       A cache command will adhere to these basic rules:
 
-      </br>
       - If you define a `:read` command, the return value of your command will
         be passed through as the result of your call to `invoke/4`.
       - If you define a `:write` command, your command must return a two-element
@@ -136,7 +133,6 @@ defmodule Cachex do
         the cache (as an update). If your command does not fit this, errors will
         happen (intentionally).
 
-      </br>
       Commands are set on a per-cache basis, but can be reused across caches. They're
       set only on cache startup and cannot be modified after the cache tree is created.
 
@@ -150,15 +146,12 @@ defmodule Cachex do
           ...> ])
           { :ok, _pid }
 
-      </br>
       Either a `Keyword` or a `Map` can be provided against the `:commands` option as
       we only use `Enum` to verify them before attaching them internally. Please see
       the `Cachex.Spec.command/1` documentation for further customization options.
 
-      </br>
     * `:compressed`
 
-      </br>
       This option will specify whether this cache should have enable ETS compression,
       which is likely to reduce memory overhead. Please note that there is a potential
       for this option to slow your cache due to compression overhead, so benchmark as
@@ -167,10 +160,8 @@ defmodule Cachex do
           iex> Cachex.start_link(:my_cache, [ compressed: true ])
           { :ok, _pid }
 
-      </br>
     * `:expiration`
 
-      </br>
       The expiration option provides the ability to customize record expiration at
       a global cache level. The value provided here must be a valid `:expiration`
       record provided by `Cachex.Spec`.
@@ -194,10 +185,8 @@ defmodule Cachex do
       Please see the `Cachex.Spec.expiration/1` documentation for further customization
       options.
 
-      </br>
     * `:fallback`
 
-      </br>
       The fallback option allows global settings related to the `fetch/4` command
       on a cache. The value provided here can either be a valid `:fallback` record
       provided by `Cachex.Spec`, or a single function (which is turned into a record
@@ -221,14 +210,11 @@ defmodule Cachex do
       state which can be passed to a fallback function if the arity is 2 rather than
       1.
 
-      </br>
       Please see the documentation for `fetch/4`, and the `Cachex.Spec.fallback/1`
       documentation for further information.
 
-      </br>
     * `:hooks`
 
-      </br>
       The `:hooks` option allow the user to attach a list of notification hooks to
       enable listening on cache actions (either before or after they happen). These
       hooks should be valid `:hook` records provided by `Cachex.Spec`. Example hook
@@ -245,10 +231,8 @@ defmodule Cachex do
 
       Please see the `Cachex.Spec.hook/1` documentation for further customization options.
 
-      </br>
     * `:limit`
 
-      </br>
       A cache limit provides a maximum size to cap the cache keyspace at. This should
       be either a positive integer, or a valid `:limit` record provided by `Cachex.Spec`.
       Internally a provided interger will just be coerced to a `:limit` record with some
@@ -272,10 +256,8 @@ defmodule Cachex do
 
       Please see the `Cachex.Spec.limit/1` documentation for further customization options.
 
-      </br>
     * `:nodes`
 
-      </br>
       A list of nodes this cache will live on, to provide distributed behaviour across
       physical nodes. This should be a list of node names, in the long form.
 
@@ -289,12 +271,10 @@ defmodule Cachex do
 
     * `:stats`
 
-      </br>
       This option can be used to toggle statistics gathering for a cache. This is a
       shorthand option to avoid attaching the `Cachex.Stats` hook manually. Statistics
       gathering has very minor overhead due to being implemented as a hook,
 
-      </br>
       Stats can be retrieve from a running cache by using `Cachex.stats/2`.
 
           iex> Cachex.start_link(:my_cache, [ stats: true ])
@@ -302,7 +282,6 @@ defmodule Cachex do
 
     * `:transactional`
 
-      </br>
       This option will specify whether this cache should have transactions and row
       locking enabled from cache startup. Please note that even if this is false,
       it will be enabled the moment a transaction is executed. It's recommended to
@@ -313,24 +292,26 @@ defmodule Cachex do
           { :ok, _pid }
 
   """
-  @spec start_link(atom | Keyword.t) :: { atom, pid }
+  @spec start_link(atom | Keyword.t()) :: {atom, pid}
   def start_link(options) when is_list(options) do
-    with { :ok,  name } <- Keyword.fetch(options, :name),
-         { :ok,  true } <- ensure_started(),
-         { :ok,  true } <- ensure_unused(name),
-         { :ok, cache } <- setup_env(name, options),
-         { :ok,   pid }  = Supervisor.start_link(__MODULE__, cache, [ name: name ]),
-         { :ok,  link }  = Informant.link(cache),
-                ^link   <- Overseer.update(name, link),
-     do: { :ok,   pid }
+    with {:ok, name} <- Keyword.fetch(options, :name),
+         {:ok, true} <- ensure_started(),
+         {:ok, true} <- ensure_unused(name),
+         {:ok, cache} <- setup_env(name, options),
+         {:ok, pid} = Supervisor.start_link(__MODULE__, cache, name: name),
+         {:ok, link} = Informant.link(cache),
+         ^link <- Overseer.update(name, link),
+         do: {:ok, pid}
   end
+
   def start_link(name) when not is_atom(name),
-   do: error(:invalid_name)
+    do: error(:invalid_name)
+
   def start_link(name),
     do: start_link(name: name)
 
   @doc false
-  @spec start_link(atom, Keyword.t) :: { atom, pid }
+  @spec start_link(atom, Keyword.t()) :: {atom, pid}
   def start_link(name, options),
     do: start_link([name: name] ++ options)
 
@@ -344,10 +325,10 @@ defmodule Cachex do
   This function is otherwise identical to `start_link/2` so please see that
   documentation for further information and configuration.
   """
-  @spec start(atom, Keyword.t) :: { atom, pid }
+  @spec start(atom, Keyword.t()) :: {atom, pid}
   def start(name, options \\ []) do
-    with { :ok, pid } <- start_link(name, options) do
-      :erlang.unlink(pid) && { :ok, pid }
+    with {:ok, pid} <- start_link(name, options) do
+      :erlang.unlink(pid) && {:ok, pid}
     end
   end
 
@@ -356,10 +337,10 @@ defmodule Cachex do
   #
   # This will start all cache services required using the `Cachex.Services`
   # module and attach them under a Supervisor instance backing the cache.
-  @spec init(cache :: Spec.cache) :: Supervisor.on_start
+  @spec init(cache :: Spec.cache()) :: Supervisor.on_start()
   def init(cache() = cache) do
     cache
-    |> Services.cache_spec
+    |> Services.cache_spec()
     |> supervise(strategy: :one_for_one)
   end
 
@@ -384,9 +365,9 @@ defmodule Cachex do
       { :ok, 0 }
 
   """
-  @spec clear(cache, Keyword.t) :: { status, integer }
+  @spec clear(cache, Keyword.t()) :: {status, integer}
   def clear(cache, options \\ []) when is_list(options),
-    do: Router.call(cache, { :clear, [ options ] })
+    do: Router.call(cache, {:clear, [options]})
 
   @doc """
   Retrieves the number of unexpired records in a cache.
@@ -405,9 +386,9 @@ defmodule Cachex do
       { :ok, 3 }
 
   """
-  @spec count(cache, Keyword.t) :: { status, number }
+  @spec count(cache, Keyword.t()) :: {status, number}
   def count(cache, options \\ []) when is_list(options),
-    do: Router.call(cache, { :count, [ options ] })
+    do: Router.call(cache, {:count, [options]})
 
   @doc """
   Decrements an entry in the cache.
@@ -418,7 +399,6 @@ defmodule Cachex do
 
     * `:initial`
 
-      </br>
       An initial value to set the key to if it does not exist. This will
       take place *before* the decrement call. Defaults to 0.
 
@@ -436,10 +416,10 @@ defmodule Cachex do
       { :ok, -3 }
 
   """
-  @spec decr(cache, any, integer, Keyword.t) :: { status, integer }
+  @spec decr(cache, any, integer, Keyword.t()) :: {status, integer}
   def decr(cache, key, amount \\ 1, options \\ [])
-  when is_integer(amount) and is_list(options) do
-    via_opt = via({ :decr, [ key, amount, options ] }, options)
+      when is_integer(amount) and is_list(options) do
+    via_opt = via({:decr, [key, amount, options]}, options)
     incr(cache, key, amount * -1, via_opt)
   end
 
@@ -462,9 +442,9 @@ defmodule Cachex do
       { :ok, nil }
 
   """
-  @spec del(cache, any, Keyword.t) :: { status, boolean }
+  @spec del(cache, any, Keyword.t()) :: {status, boolean}
   def del(cache, key, options \\ []) when is_list(options),
-    do: Router.call(cache, { :del, [ key, options ] })
+    do: Router.call(cache, {:del, [key, options]})
 
   @doc """
   Serializes a cache to a location on a filesystem.
@@ -480,11 +460,9 @@ defmodule Cachex do
 
     * `:compression`
 
-      </br>
       Specifies the level of compression to apply when serializing (0-9). This
       will default to level 1 compression, which is appropriate for most dumps.
 
-      </br>
       Using a compression level of 0 will disable compression completely. This
       will result in a faster serialization but at the cost of higher space.
 
@@ -497,10 +475,10 @@ defmodule Cachex do
       { :ok, true }
 
   """
-  @spec dump(cache, binary, Keyword.t) :: { status, any }
+  @spec dump(cache, binary, Keyword.t()) :: {status, any}
   def dump(cache, path, options \\ [])
-  when is_binary(path) and is_list(options),
-    do: Router.call(cache, { :dump, [ path, options ] })
+      when is_binary(path) and is_list(options),
+      do: Router.call(cache, {:dump, [path, options]})
 
   @doc """
   Determines whether a cache contains any entries.
@@ -520,9 +498,9 @@ defmodule Cachex do
       { :ok, true }
 
   """
-  @spec empty?(cache, Keyword.t) :: { status, boolean }
+  @spec empty?(cache, Keyword.t()) :: {status, boolean}
   def empty?(cache, options \\ []) when is_list(options),
-    do: Router.call(cache, { :empty?, [ options ] })
+    do: Router.call(cache, {:empty?, [options]})
 
   @doc """
   Executes multiple functions in the context of a cache.
@@ -550,11 +528,11 @@ defmodule Cachex do
       { :ok, [ "value1", "value2" ] }
 
   """
-  @spec execute(cache, function, Keyword.t) :: { status, any }
+  @spec execute(cache, function, Keyword.t()) :: {status, any}
   def execute(cache, operation, options \\ [])
-  when is_function(operation, 1) and is_list(options) do
-    Overseer.enforce(cache) do
-      { :ok, operation.(cache) }
+      when is_function(operation, 1) and is_list(options) do
+    Overseer.enforce cache do
+      {:ok, operation.(cache)}
     end
   end
 
@@ -574,9 +552,9 @@ defmodule Cachex do
       { :ok, false }
 
   """
-  @spec exists?(cache, any, Keyword.t) :: { status, boolean }
+  @spec exists?(cache, any, Keyword.t()) :: {status, boolean}
   def exists?(cache, key, options \\ []) when is_list(options),
-    do: Router.call(cache, { :exists?, [ key, options ] })
+    do: Router.call(cache, {:exists?, [key, options]})
 
   @doc """
   Places an expiration time on an entry in a cache.
@@ -597,10 +575,10 @@ defmodule Cachex do
       { :ok, false }
 
   """
-  @spec expire(cache, any, number | nil, Keyword.t) :: { status, boolean }
+  @spec expire(cache, any, number | nil, Keyword.t()) :: {status, boolean}
   def expire(cache, key, expiration, options \\ [])
-  when (is_nil(expiration) or is_number(expiration)) and is_list(options),
-    do: Router.call(cache, { :expire, [ key, expiration, options ] })
+      when (is_nil(expiration) or is_number(expiration)) and is_list(options),
+      do: Router.call(cache, {:expire, [key, expiration, options]})
 
   @doc """
   Updates an entry in a cache to expire at a given time.
@@ -619,10 +597,10 @@ defmodule Cachex do
       { :ok, false }
 
   """
-  @spec expire_at(cache, binary, number, Keyword.t) :: { status, boolean }
+  @spec expire_at(cache, binary, number, Keyword.t()) :: {status, boolean}
   def expire_at(cache, key, timestamp, options \\ [])
-  when is_number(timestamp) and is_list(options) do
-    via_opts = via({ :expire_at, [ key, timestamp, options ] }, options)
+      when is_number(timestamp) and is_list(options) do
+    via_opts = via({:expire_at, [key, timestamp, options]}, options)
     expire(cache, key, timestamp - now(), via_opts)
   end
 
@@ -643,9 +621,9 @@ defmodule Cachex do
       { :ok, [ { :entry, "key", 1538714590095, nil, "value" } ] }
 
   """
-  @spec export(cache, Keyword.t) :: { status, [ Spec.entry ] }
+  @spec export(cache, Keyword.t()) :: {status, [Spec.entry()]}
   def export(cache, options \\ []) when is_list(options),
-    do: Router.call(cache, { :export, [ options ] })
+    do: Router.call(cache, {:export, [options]})
 
   @doc """
   Fetches an entry from a cache, generating a value on cache miss.
@@ -695,12 +673,13 @@ defmodule Cachex do
       { :commit, "yek_gnissim" }
 
   """
-  @spec fetch(cache, any, function | nil, Keyword.t) :: { status | :commit | :ignore, any }
+  @spec fetch(cache, any, function | nil, Keyword.t()) :: {status | :commit | :ignore, any}
   def fetch(cache, key, fallback \\ nil, options \\ []) when is_list(options) do
-    Overseer.enforce(cache) do
+    Overseer.enforce cache do
       case fallback || fallback(cache(cache, :fallback), :default) do
         val when is_function(val) ->
-          Router.call(cache, { :fetch, [ key, val, options ] })
+          Router.call(cache, {:fetch, [key, val, options]})
+
         _na ->
           error(:invalid_fallback)
       end
@@ -720,9 +699,9 @@ defmodule Cachex do
       { :ok, nil }
 
   """
-  @spec get(cache, any, Keyword.t) :: { atom, any }
+  @spec get(cache, any, Keyword.t()) :: {atom, any}
   def get(cache, key, options \\ []) when is_list(options),
-    do: Router.call(cache, { :get, [ key, options ] })
+    do: Router.call(cache, {:get, [key, options]})
 
   @doc """
   Retrieves and updates an entry in a cache.
@@ -748,10 +727,10 @@ defmodule Cachex do
       { :ignore, nil }
 
   """
-  @spec get_and_update(cache, any, function, Keyword.t) :: { :commit | :ignore, any }
+  @spec get_and_update(cache, any, function, Keyword.t()) :: {:commit | :ignore, any}
   def get_and_update(cache, key, update_function, options \\ [])
-  when is_function(update_function) and is_list(options),
-    do: Router.call(cache, { :get_and_update, [ key, update_function, options ] })
+      when is_function(update_function) and is_list(options),
+      do: Router.call(cache, {:get_and_update, [key, update_function, options]})
 
   @doc """
   Retrieves a list of all entry keys from a cache.
@@ -771,9 +750,9 @@ defmodule Cachex do
       { :ok, [] }
 
   """
-  @spec keys(cache, Keyword.t) :: { status, [ any ] }
+  @spec keys(cache, Keyword.t()) :: {status, [any]}
   def keys(cache, options \\ []) when is_list(options),
-    do: Router.call(cache, { :keys, [ options ] })
+    do: Router.call(cache, {:keys, [options]})
 
   @doc """
   Imports an export set into a cache.
@@ -788,10 +767,10 @@ defmodule Cachex do
       { :ok, true }
 
   """
-  @spec import(cache, [ Spec.entry ], Keyword.t) :: { status, any }
+  @spec import(cache, [Spec.entry()], Keyword.t()) :: {status, any}
   def import(cache, entries, options \\ [])
-  when is_list(entries) and is_list(options),
-    do: Router.call(cache, { :import, [ entries, options ] })
+      when is_list(entries) and is_list(options),
+      do: Router.call(cache, {:import, [entries, options]})
 
   @doc """
   Increments an entry in the cache.
@@ -802,7 +781,6 @@ defmodule Cachex do
 
     * `:initial`
 
-      </br>
       An initial value to set the key to if it does not exist. This will
       take place *before* the increment call. Defaults to 0.
 
@@ -820,10 +798,10 @@ defmodule Cachex do
       { :ok, 7 }
 
   """
-  @spec incr(cache, any, integer, Keyword.t) :: { status, integer }
+  @spec incr(cache, any, integer, Keyword.t()) :: {status, integer}
   def incr(cache, key, amount \\ 1, options \\ [])
-  when is_integer(amount) and is_list(options),
-    do: Router.call(cache, { :incr, [ key, amount, options ] })
+      when is_integer(amount) and is_list(options),
+      do: Router.call(cache, {:incr, [key, amount, options]})
 
   @doc """
   Inspects various aspects of a cache.
@@ -844,51 +822,37 @@ defmodule Cachex do
 
     * `:cache`
 
-      </br>
       Retrieves the internal cache record for a cache.
 
-      </br>
     * `{ :entry, key }`
 
-      </br>
       Retrieves a raw entry record from inside a cache.
 
     * `{ :expired, :count }`
 
-      </br>
       Retrieves the number of expired entries which currently live in the cache
       but have not yet been removed by cleanup tasks (either scheduled or lazy).
 
-      </br>
     * `{ :expired, :keys }`
 
-      </br>
       Retrieves the list of expired entry keys which current live in the cache
       but have not yet been removed by cleanup tasks (either scheduled or lazy).
 
-      </br>
     * `{ :janitor, :last }`
 
-      </br>
       Retrieves metadata about the last execution of the Janitor service for
       the specified cache.
 
-      </br>
     * `{ :memory, :bytes }`
 
-      </br>
       Retrieves an approximate memory footprint of a cache in bytes.
 
-      </br>
     * `{ :memory, :binary }`
 
-      </br>
       Retrieves an approximate memory footprint of a cache in binary format.
 
-      </br>
     * `{ :memory, :words }`
 
-      </br>
       Retrieve an approximate memory footprint of a cache as a number of
       machine words.
 
@@ -921,9 +885,9 @@ defmodule Cachex do
       { :ok, 1328 }
 
   """
-  @spec inspect(cache, atom | tuple, Keyword.t) :: { status, any }
+  @spec inspect(cache, atom | tuple, Keyword.t()) :: {status, any}
   def inspect(cache, option, options \\ []) when is_list(options),
-    do: Router.call(cache, { :inspect, [ option, options ] })
+    do: Router.call(cache, {:inspect, [option, options]})
 
   @doc """
   Invokes a custom command against a cache entry.
@@ -947,9 +911,9 @@ defmodule Cachex do
       { :ok, 3 }
 
   """
-  @spec invoke(cache, atom, any, Keyword.t) :: any
+  @spec invoke(cache, atom, any, Keyword.t()) :: any
   def invoke(cache, cmd, key, options \\ []) when is_list(options),
-    do: Router.call(cache, { :invoke, [ cmd, key, options ] })
+    do: Router.call(cache, {:invoke, [cmd, key, options]})
 
   @doc """
   Deserializes a cache from a location on a filesystem.
@@ -981,10 +945,10 @@ defmodule Cachex do
       { :ok, 1 }
 
   """
-  @spec load(cache, binary, Keyword.t) :: { status, any }
+  @spec load(cache, binary, Keyword.t()) :: {status, any}
   def load(cache, path, options \\ [])
-  when is_binary(path) and is_list(options),
-    do: Router.call(cache, { :load, [ path, options ] })
+      when is_binary(path) and is_list(options),
+      do: Router.call(cache, {:load, [path, options]})
 
   @doc """
   Removes an expiration time from an entry in a cache.
@@ -999,9 +963,9 @@ defmodule Cachex do
       { :ok, false }
 
   """
-  @spec persist(cache, any, Keyword.t) :: { status, boolean }
+  @spec persist(cache, any, Keyword.t()) :: {status, boolean}
   def persist(cache, key, options \\ []) when is_list(options),
-    do: expire(cache, key, nil, via({ :persist, [ key, options ] }, options))
+    do: expire(cache, key, nil, via({:persist, [key, options]}, options))
 
   @doc """
   Triggers a cleanup of all expired entries in a cache.
@@ -1017,9 +981,9 @@ defmodule Cachex do
       { :ok, 15 }
 
   """
-  @spec purge(cache, Keyword.t) :: { status, number }
+  @spec purge(cache, Keyword.t()) :: {status, number}
   def purge(cache, options \\ []) when is_list(options),
-    do: Router.call(cache, { :purge, [ options ] })
+    do: Router.call(cache, {:purge, [options]})
 
   @doc """
   Places an entry in a cache.
@@ -1031,7 +995,6 @@ defmodule Cachex do
 
     * `:ttl`
 
-      </br>
       An expiration time to set for the provided key (time-to-live), overriding
       any default expirations set on a cache. This value should be in milliseconds.
 
@@ -1046,9 +1009,9 @@ defmodule Cachex do
 
   """
   # TODO: maybe rename TTL to be expiration?
-  @spec put(cache, any, any, Keyword.t) :: { status, boolean }
+  @spec put(cache, any, any, Keyword.t()) :: {status, boolean}
   def put(cache, key, value, options \\ []) when is_list(options),
-    do: Router.call(cache, { :put, [ key, value, options ] })
+    do: Router.call(cache, {:put, [key, value, options]})
 
   @doc """
   Places a batch of entries in a cache.
@@ -1062,7 +1025,6 @@ defmodule Cachex do
 
     * `:ttl`
 
-      </br>
       An expiration time to set for the provided keys (time-to-live), overriding
       any default expirations set on a cache. This value should be in milliseconds.
 
@@ -1077,10 +1039,10 @@ defmodule Cachex do
 
   """
   # TODO: maybe rename TTL to be expiration?
-  @spec put_many(cache, [ { any, any } ], Keyword.t) :: { status, boolean }
+  @spec put_many(cache, [{any, any}], Keyword.t()) :: {status, boolean}
   def put_many(cache, pairs, options \\ [])
-  when is_list(pairs) and is_list(options),
-    do: Router.call(cache, { :put_many, [ pairs, options ] })
+      when is_list(pairs) and is_list(options),
+      do: Router.call(cache, {:put_many, [pairs, options]})
 
   @doc """
   Refreshes an expiration for an entry in a cache.
@@ -1105,9 +1067,9 @@ defmodule Cachex do
       { :ok, false }
 
   """
-  @spec refresh(cache, any, Keyword.t) :: { status, boolean }
+  @spec refresh(cache, any, Keyword.t()) :: {status, boolean}
   def refresh(cache, key, options \\ []) when is_list(options),
-    do: Router.call(cache, { :refresh, [ key, options ] })
+    do: Router.call(cache, {:refresh, [key, options]})
 
   @doc """
   Resets a cache by clearing the keyspace and restarting any hooks.
@@ -1116,16 +1078,13 @@ defmodule Cachex do
 
     * `:hooks`
 
-      </br>
       A whitelist of hooks to reset on the cache instance (call the
       initialization phase of a hook again). This will default to
       resetting all hooks associated with a cache, which is usually
       the desired behaviour.
 
-      </br>
     * `:only`
 
-      </br>
       A whitelist of components to reset, which can currently contain
       either the `:cache` or `:hooks` tag to determine what to reset.
       This will default to `[ :cache, :hooks ]`.
@@ -1147,15 +1106,16 @@ defmodule Cachex do
       { :ok, true }
 
   """
-  @spec reset(cache, Keyword.t) :: { status, true }
+  @spec reset(cache, Keyword.t()) :: {status, true}
   def reset(cache, options \\ []) when is_list(options),
-    do: Router.call(cache, { :reset, [ options ] })
+    do: Router.call(cache, {:reset, [options]})
 
   @doc """
   Deprecated implementation delegate of `put/4`.
   """
   if Version.match?(System.version(), ">= 1.6.0"),
-    do: @deprecated "Please migrate to using put/4 instead."
+    do: @deprecated("Please migrate to using put/4 instead.")
+
   def set(cache, key, value, options \\ []),
     do: put(cache, key, value, options)
 
@@ -1163,7 +1123,8 @@ defmodule Cachex do
   Deprecated implementation delegate of `put_many/3`.
   """
   if Version.match?(System.version(), ">= 1.6.0"),
-    do: @deprecated "Please migrate to using put_many/3 instead."
+    do: @deprecated("Please migrate to using put_many/3 instead.")
+
   def set_many(cache, pairs, options \\ []),
     do: put_many(cache, pairs, options)
 
@@ -1184,9 +1145,9 @@ defmodule Cachex do
       { :ok, 3 }
 
   """
-  @spec size(cache, Keyword.t) :: { status, number }
+  @spec size(cache, Keyword.t()) :: {status, number}
   def size(cache, options \\ []) when is_list(options),
-    do: Router.call(cache, { :size, [ options ] })
+    do: Router.call(cache, {:size, [options]})
 
   @doc """
   Retrieves statistics about a cache.
@@ -1198,7 +1159,6 @@ defmodule Cachex do
 
     * `:for`
 
-      </br>
       Allows customization of exactly which statistics to retrieve.
 
   ## Examples
@@ -1210,9 +1170,9 @@ defmodule Cachex do
       { :error, :stats_disabled }
 
   """
-  @spec stats(cache, Keyword.t) :: { status, %{ } }
+  @spec stats(cache, Keyword.t()) :: {status, %{}}
   def stats(cache, options \\ []) when is_list(options),
-    do: Router.call(cache, { :stats, [ options ] })
+    do: Router.call(cache, {:stats, [options]})
 
   @doc """
   Creates a `Stream` of entries in a cache.
@@ -1228,7 +1188,6 @@ defmodule Cachex do
 
     * `:batch_size`
 
-      </br>
       Allows customization of the internal batching when paginating the QLC
       cursor coming back from ETS. It's unlikely this will ever need changing.
 
@@ -1257,10 +1216,10 @@ defmodule Cachex do
       [{"b", 2}, {"c", 3}, {"a", 1}]
 
   """
-  @spec stream(cache, any, Keyword.t) :: { status, Enumerable.t }
+  @spec stream(cache, any, Keyword.t()) :: {status, Enumerable.t()}
   def stream(cache, query \\ Query.create(true), options \\ [])
-  when is_list(options),
-    do: Router.call(cache, { :stream, [ query, options ] })
+      when is_list(options),
+      do: Router.call(cache, {:stream, [query, options]})
 
   @doc """
   Takes an entry from a cache.
@@ -1281,9 +1240,9 @@ defmodule Cachex do
       { :ok, nil }
 
   """
-  @spec take(cache, any, Keyword.t) :: { status, any }
+  @spec take(cache, any, Keyword.t()) :: {status, any}
   def take(cache, key, options \\ []) when is_list(options),
-    do: Router.call(cache, { :take, [ key, options ] })
+    do: Router.call(cache, {:take, [key, options]})
 
   @doc """
   Updates the last write time on a cache entry.
@@ -1291,9 +1250,9 @@ defmodule Cachex do
   This is very similar to `refresh/3` except that the expiration
   time is maintained inside the record (using a calculated offset).
   """
-  @spec touch(cache, any, Keyword.t) :: { status, boolean }
+  @spec touch(cache, any, Keyword.t()) :: {status, boolean}
   def touch(cache, key, options \\ []) when is_list(options),
-    do: Router.call(cache, { :touch, [ key, options ] })
+    do: Router.call(cache, {:touch, [key, options]})
 
   @doc """
   Executes multiple functions in the context of a transaction.
@@ -1317,20 +1276,22 @@ defmodule Cachex do
       { :ok, [ "value1", "value2" ] }
 
   """
-  @spec transaction(cache, [ any ], function, Keyword.t) :: { status, any }
+  @spec transaction(cache, [any], function, Keyword.t()) :: {status, any}
   def transaction(cache, keys, operation, options \\ [])
-  when is_function(operation, 1) and is_list(keys) and is_list(options) do
-    Overseer.enforce(cache) do
+      when is_function(operation, 1) and is_list(keys) and is_list(options) do
+    Overseer.enforce cache do
       trans_cache =
         case cache(cache, :transactional) do
-          true  -> cache
+          true ->
+            cache
+
           false ->
             cache
             |> cache(:name)
             |> Overseer.update(&cache(&1, transactional: true))
         end
 
-      Router.call(trans_cache, { :transaction, [ keys, operation, options ] })
+      Router.call(trans_cache, {:transaction, [keys, operation, options]})
     end
   end
 
@@ -1353,9 +1314,9 @@ defmodule Cachex do
       { :ok, nil }
 
   """
-  @spec ttl(cache, any, Keyword.t) :: { status, integer | nil }
+  @spec ttl(cache, any, Keyword.t()) :: {status, integer | nil}
   def ttl(cache, key, options \\ []) when is_list(options),
-    do: Router.call(cache, { :ttl, [ key, options ] })
+    do: Router.call(cache, {:ttl, [key, options]})
 
   @doc """
   Updates an entry in a cache.
@@ -1379,9 +1340,9 @@ defmodule Cachex do
       { :ok, false }
 
   """
-  @spec update(cache, any, any, Keyword.t) :: { status, any }
+  @spec update(cache, any, any, Keyword.t()) :: {status, any}
   def update(cache, key, value, options \\ []) when is_list(options),
-    do: Router.call(cache, { :update, [ key, value, options ] })
+    do: Router.call(cache, {:update, [key, value, options]})
 
   ###############
   # Private API #
@@ -1393,7 +1354,7 @@ defmodule Cachex do
   # started, otherwise a truthy result will be returned.
   defp ensure_started do
     if Overseer.started?() do
-      { :ok, true }
+      {:ok, true}
     else
       error(:not_started)
     end
@@ -1404,8 +1365,8 @@ defmodule Cachex do
   # If the name is in use, we return an error.
   defp ensure_unused(cache) do
     case GenServer.whereis(cache) do
-      nil -> { :ok, true }
-      pid -> { :error, { :already_started, pid } }
+      nil -> {:ok, true}
+      pid -> {:error, {:already_started, pid}}
     end
   end
 
@@ -1420,11 +1381,11 @@ defmodule Cachex do
   # our table and so the Supervisor would simply crash on invalid
   # table options, which does not allow us to explain to the user.
   defp setup_env(name, options) when is_list(options) do
-    with { :ok, cache } <- Options.parse(name, options) do
+    with {:ok, cache} <- Options.parse(name, options) do
       try do
-        :ets.new(name, [ :named_table | const(:table_options) ])
+        :ets.new(name, [:named_table | const(:table_options)])
         :ets.delete(name)
-        { :ok, cache }
+        {:ok, cache}
       rescue
         _ -> error(:invalid_option)
       end
@@ -1437,10 +1398,12 @@ defmodule Cachex do
   # bang functions for the API. This will expand error messages and
   # remove the binding Tuples in order to allow for easy piping of
   # results from cache calls.
-  defp unwrap_unsafe({ :error, value }) when is_atom(value),
-    do: raise ExecutionError, message: Errors.long_form(value)
-  defp unwrap_unsafe({ :error, value }) when is_binary(value),
-    do: raise ExecutionError, message: value
-  defp unwrap_unsafe({ _state, value }),
+  defp unwrap_unsafe({:error, value}) when is_atom(value),
+    do: raise(ExecutionError, message: Errors.long_form(value))
+
+  defp unwrap_unsafe({:error, value}) when is_binary(value),
+    do: raise(ExecutionError, message: value)
+
+  defp unwrap_unsafe({_state, value}),
     do: value
 end


### PR DESCRIPTION
Removes line breaks from `lib/cachex.ex`. My editor also ran the formatter. If you want i can run on the whole project and add to CI.