### PR TITLE
Allow unsafer Cachex.Disk.read/3 to Support runtime defined Atoms

### DIFF
--- a/lib/cachex/disk.ex
+++ b/lib/cachex/disk.ex
@@ -27,10 +27,10 @@ defmodule Cachex.Disk do
   it safely to avoid malicious content (although the chance of that is slim).
   """
   @spec read(binary, Keyword.t) :: { :ok, any } | { :error, atom }
-  def read(path, options \\ []) when is_binary(path) and is_list(options) do
+  def read(path, options \\ [:safe]) when is_binary(path) and is_list(options) do
     path
     |> File.read!
-    |> :erlang.binary_to_term([ :safe ])
+    |> :erlang.binary_to_term(options)
     |> wrap(:ok)
   rescue
     _ -> error(:unreachable_file)


### PR DESCRIPTION
default Behavior is kept to use :safe binary_to_term but allows opt-out
using empty Keyword list as options

fixes
https://github.com/whitfin/cachex/issues/251#issuecomment-768447225


please tell me if i should change anything, u free to do whatever u want with it, thanks for the great library