### PR TITLE
Update Cachex.stream/3 doc

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -1217,8 +1217,8 @@ defmodule Cachex do
   @doc """
   Creates a `Stream` of entries in a cache.
 
-  This will stream all entries matching the provided match specification
-  as the second argument. If none if provided, it will default to all entries
+  This will stream all entries matching the match specification provided
+  as the second argument. If none is provided, it will default to all entries
   which are yet to expire (in no particular order).
 
   Consider using `Cachex.Query` to generate match specifications used when


### PR DESCRIPTION
Slightly re-phrases the doc for clarity and fixes a typo for `Cachex.stream/3`.