### PR TITLE
Let Elixir manage applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -75,12 +75,7 @@ defmodule Cachex.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     [
-      applications: [
-        :logger,
-        :eternal,
-        :sleeplocks,
-        :jumper
-      ],
+      extra_applications: [:logger],
       mod: {Cachex.Application, []}
     ]
   end


### PR DESCRIPTION
To deal with 
```
warning: Unsafe.Generator.__using__/1 defined in application :unsafe is used by the current application but the current application does not directly depend on :unsafe. To fix this, you must do one of:

  1. If :unsafe is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :unsafe is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :unsafe, you may optionally skip this warning by adding [xref: [exclude: Unsafe.Generator]] to your "def project" in mix.exs

  lib/cachex.ex:36: Cachex
```