### PR TITLE
Drop elixir 1.3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         elixir:
           - '1.11'
         include:
+          - elixir: '1.11'
+            otp: '22.3'
           - elixir: '1.10'
             otp: '21.3'
           - elixir: '1.9'
@@ -31,8 +33,6 @@ jobs:
           - elixir: '1.5'
             otp: '18.3'
           - elixir: '1.4'
-            otp: '18.3'
-          - elixir: '1.2'
             otp: '18.3'
 
     steps:

--- a/README.md
+++ b/README.md
@@ -74,14 +74,6 @@ def deps do
 end
 ```
 
-  2. Ensure cachex is started before your application:
-
-```elixir
-def application do
-  [applications: [:cachex]]
-end
-```
-
 ## Usage
 
 In the most typical use of Cachex, you only need to add your cache as a child of your application. If you created your project via `Mix` (passing the `--sup` flag) this is handled in `lib/my_app/application.ex`. This file will already contain an empty list of children to add to your application - simply add entries for your cache to this list:

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Cachex.Mixfile do
         maintainers: [ "Isaac Whitfield" ]
       },
       version: @version,
-      elixir: "~> 1.2",
+      elixir: "~> 1.4",
       deps: deps(),
       docs: [
         source_ref: "v#{@version}",


### PR DESCRIPTION
Elixir 1.4 is 4 years old now and is generally a good minimum version

Add Elixir 1.11 to CI matrix

Remove the recommendation to set `applications` in an end user's mix.exs because doing so will break their application if they use `mix release`