### PR TITLE
Add ttl support for fetch function

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -652,6 +652,13 @@ defmodule Cachex do
   in the `:fallback` option at cache startup, the third argument to
   this call becomes optional.
 
+  ## Options
+
+    * `:ttl`
+
+      An expiration time to set for the provided keys (time-to-live), overriding
+      any default expirations set on a cache. This value should be in milliseconds.
+
   ## Examples
 
       iex> Cachex.put(:my_cache, "key", "value")
@@ -668,6 +675,11 @@ defmodule Cachex do
       iex> Cachex.fetch(:my_cache, "missing_key", fn(key) ->
       ...>   { :commit, String.reverse(key) }
       ...> end)
+      { :commit, "yek_gnissim" }
+
+      iex> Cachex.fetch(:my_cache, "ttl_key", fn(key) ->
+      ...>   { :commit, String.reverse(key) }
+      ...> end, ttl: 1_000)
       { :commit, "yek_gnissim" }
 
   """

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -680,7 +680,7 @@ defmodule Cachex do
       iex> Cachex.fetch(:my_cache, "ttl_key", fn(key) ->
       ...>   { :commit, String.reverse(key) }
       ...> end, ttl: 1_000)
-      { :commit, "yek_gnissim" }
+      { :commit, "yek_ltt" }
 
   """
   @spec fetch(cache, any, function | nil, Keyword.t) :: { status | :commit | :ignore, any }

--- a/lib/cachex/actions/fetch.ex
+++ b/lib/cachex/actions/fetch.ex
@@ -29,9 +29,9 @@ defmodule Cachex.Actions.Fetch do
   in the cache; otherwise it is immediately returned. Any fetched values will be
   placed in the cache in order to allow read-through caches.
   """
-  def execute(cache() = cache, key, fallback, _options) do
+  def execute(cache() = cache, key, fallback, options) do
     with { :ok, nil } <- Get.execute(cache, key, []) do
-      Courier.dispatch(cache, key, generate_task(cache, fallback, key))
+      Courier.dispatch(cache, key, generate_task(cache, fallback, key), options)
     end
   end
 

--- a/test/cachex/actions/fetch_test.exs
+++ b/test/cachex/actions/fetch_test.exs
@@ -96,6 +96,22 @@ defmodule Cachex.Actions.FetchTest do
     assert(result9 == { :error, :invalid_fallback })
   end
 
+  test "inserting values via the fallback function supports ttl" do
+    cache = Helper.create_cache()
+
+    # insert a value via the fallback function
+    result = Cachex.fetch(cache, "key", &String.reverse/1, ttl: 5)
+
+    # confirm value is present
+    assert {:ok, "yek"} == Cachex.get(cache, "key")
+
+    # wait for ttl to expire
+    :timer.sleep(10)
+
+    # confirm value is no longer present
+    assert {:ok, nil} == Cachex.get(cache, "key")
+  end
+
   # This test ensures that the fallback is executed just once when a
   # fallback commit and another fetch on the same key occur simultaneously.
   test "fetching and committing the same key simultaneously from a fallback" do


### PR DESCRIPTION
The `fetch` function now honours the `:ttl` option by passing it to the `put` function.

RE: https://github.com/whitfin/cachex/issues/282