### PR TITLE
Add purge options to allow detailed eviction hook usage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 erl_crash.dump
 mix.lock
 *.ez
+*.code-workspace
+

--- a/lib/cachex/errors.ex
+++ b/lib/cachex/errors.ex
@@ -21,7 +21,7 @@ defmodule Cachex.Errors do
     :janitor_disabled,    :no_cache,
     :non_distributed,     :non_numeric_value,
     :not_started,         :stats_disabled,
-    :unreachable_file
+    :unreachable_file,    :invalid_purge
   ]
 
   ##########
@@ -95,6 +95,8 @@ defmodule Cachex.Errors do
     do: "Stats are not enabled for the specified cache"
   def long_form(:unreachable_file),
     do: "Unable to access provided file path"
+  def long_form(:invalid_purge),
+    do: "Invalid purge options provided"
   def long_form(error),
     do: error
 end

--- a/lib/cachex/options.ex
+++ b/lib/cachex/options.ex
@@ -25,7 +25,8 @@ defmodule Cachex.Options do
     :compressed,
     :expiration,
     :transactional,
-    :warmers
+    :warmers,
+    :purge
   ]
 
   ##############
@@ -320,6 +321,19 @@ defmodule Cachex.Options do
     case validated?(warmers, :warmer) do
       false -> error(:invalid_warmer)
       true  -> cache(cache, warmers: warmers)
+    end
+  end
+
+  defp parse_type(:purge, cache, options) do
+    purge =
+      case Keyword.get(options, :purge) do
+        nil -> purge(include_result_data: false)
+        purge -> purge
+      end
+
+    case Validator.valid?(:purge, purge) do
+      false -> error(:invalid_purge)
+      true  -> cache(cache, purge: purge)
     end
   end
 

--- a/lib/cachex/services/janitor.ex
+++ b/lib/cachex/services/janitor.ex
@@ -104,9 +104,11 @@ defmodule Cachex.Services.Janitor do
     start_time = now()
     new_caches = Overseer.retrieve(name)
 
-    { duration, { :ok, count } = result } = :timer.tc(fn ->
+    { duration, result } = :timer.tc(fn ->
       Cachex.purge(new_caches, const(:local))
     end)
+
+    count = elem(result, 1)
 
     case count do
       0 -> nil

--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -112,7 +112,8 @@ defmodule Cachex.Spec do
     limit: nil,
     nodes: [],
     transactional: false,
-    warmers: []
+    warmers: [],
+    purge: nil
 
   @doc """
   Creates a command record from the provided values.
@@ -244,6 +245,10 @@ defmodule Cachex.Spec do
     module: nil,
     state: nil
 
+
+  defrecord :purge,
+    include_result_data: false
+
   ###############
   # Record Docs #
   ###############
@@ -301,6 +306,9 @@ defmodule Cachex.Spec do
   """
   @spec warmer(warmer, Keyword.t) :: warmer
   defmacro warmer(record, args)
+
+  # @spec purge(purge, Keyword.t) :: purge
+  defmacro purge(record, args)
 
   #############
   # Constants #

--- a/lib/cachex/spec/validator.ex
+++ b/lib/cachex/spec/validator.ex
@@ -121,6 +121,9 @@ defmodule Cachex.Spec.Validator do
           and { :interval, 0 } in module.__info__(:functions)
           and { :execute,  1 } in module.__info__(:functions)
 
+  def valid?(:purge, purge(include_result_data: include_result_data)),
+    do: is_boolean(include_result_data)
+
   # Catch-all for invalid records.
   def valid?(_tag, _val),
     do: false


### PR DESCRIPTION
#### Overview  
Add an opt-in behaviour that exposes purged records from a cache.

Note: I'm not expecting the PR to land as-is. I am aiming for a feature discussion. I have made a branch on my fork that I am using for a small project. 

#### Why?
The code I'm using is using 3 caches. 

Cache 1: entries with a key like `group` - where I keep information about a group

Cache 2: entries with key like `group:id` - where I want to limit the number of entries with `group` prefix to an arbitrary size.

Cache 3: entries with a key like `group` and is a counter of records for a group in Cache 2

I am using Cache 3 to artificially create a limit on Cache 2 entries, enforcing an arbitrary limit - new entries for Cache 2 that exceed a limit held in Cache 3 should be rejected. Evictions in Cache 2 take place only via ttl expiration.

```elixir
def insert_cache2(key, value) do
  if Cachex.get(:group_index, group) > 1  do
    Cachex.put(:group_id, some_value)
  else
    {:error, :group_full}
  end
end
```

#### Alternative
 Is it more feasible to simply start a new Cache process for each `group` instead of using Cache 2 this way? Example 
```elixir
# on start
Enum.each(Cachex.stream(Cachex.Query.create(true, :key)), fn group -> DynamicSupervisor.start_child(MyApp.DynamicSupervisor, {Cachex, name: String.to_atom(group)} end)

# insert group
def create_group(group) do
  Cachex.put!(:groups, group_data)
  DynamicSupervisor.start_child(MyApp.DynamicSupervisor, {Cachex, name: String.to_atom(group)) end)
end

# insert group id 
def insert(group, id) do
  if Cachex.size!(String.to_atom(group)) < limit do
    Cachex.put!(String.to_atom(group), id, some_record)
  else 
    {:error, :full}
  end
end
```
