### PR TITLE
Add support for non-synchronous warmers

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -74,7 +74,7 @@
         {Credo.Check.Refactor.NegatedConditionsWithElse},
         {Credo.Check.Refactor.Nesting},
         {Credo.Check.Refactor.PipeChainStart},
-        {Credo.Check.Refactor.CyclomaticComplexity},
+        {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 10},
         {Credo.Check.Refactor.NegatedConditionsInUnless},
         {Credo.Check.Refactor.NegatedConditionsWithElse},
         {Credo.Check.Refactor.Nesting},

--- a/.credo.exs
+++ b/.credo.exs
@@ -67,7 +67,6 @@
         {Credo.Check.Refactor.ABCSize, max_size: 50},
         {Credo.Check.Refactor.CaseTrivialMatches, false},
         {Credo.Check.Refactor.CondStatements},
-        {Credo.Check.Refactor.CyclomaticComplexity},
         {Credo.Check.Refactor.FunctionArity},
         {Credo.Check.Refactor.MatchInCondition},
         {Credo.Check.Refactor.NegatedConditionsInUnless},

--- a/lib/cachex/services/incubator.ex
+++ b/lib/cachex/services/incubator.ex
@@ -34,6 +34,9 @@ defmodule Cachex.Services.Incubator do
   ###############
 
   # Generates a Supervisor specification for a hook.
-  defp spec(warmer(module: module, state: state), cache),
-    do: %{id: module, start: {GenServer, :start_link, [module, {cache, state}]}}
+  defp spec(warmer(module: module) = warmer, cache),
+    do: %{
+      id: module,
+      start: {GenServer, :start_link, [module, {cache, warmer}]}
+    }
 end

--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -97,7 +97,8 @@ defmodule Cachex.Spec do
   @type warmer ::
           record(:warmer,
             module: atom,
-            state: any
+            state: any,
+            sync: boolean
           )
 
   ###########
@@ -251,7 +252,8 @@ defmodule Cachex.Spec do
   """
   defrecord :warmer,
     module: nil,
-    state: nil
+    state: nil,
+    sync: true
 
   ###############
   # Record Docs #

--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -98,7 +98,7 @@ defmodule Cachex.Spec do
           record(:warmer,
             module: atom,
             state: any,
-            sync: boolean
+            async: boolean
           )
 
   ###########
@@ -253,7 +253,7 @@ defmodule Cachex.Spec do
   defrecord :warmer,
     module: nil,
     state: nil,
-    sync: true
+    async: false
 
   ###############
   # Record Docs #

--- a/lib/cachex/spec/validator.ex
+++ b/lib/cachex/spec/validator.ex
@@ -92,9 +92,8 @@ defmodule Cachex.Spec.Validator do
     check3 = check2 and nillable?(name, &(is_atom(&1) or is_pid(&1)))
     check4 = check3 and nillable?(module.timeout(), &is_positive_integer/1)
 
-    check5 =
-      check4 and
-        (enum?(module.actions(), &is_atom/1) or module.actions() == :all)
+    action = check4 and module.actions()
+    check5 = check4 and (enum?(action, &is_atom/1) or action == :all)
 
     check6 = check5 and enum?(module.provisions(), &is_atom/1)
     check7 = check6 and module.type() in [:post, :pre]

--- a/lib/cachex/warmer.ex
+++ b/lib/cachex/warmer.ex
@@ -74,7 +74,7 @@ defmodule Cachex.Warmer do
         if sync do
           handle_info(:cachex_warmer, {cache, state})
         else
-          trigger()
+          send(self(), :cachex_warmer)
         end
 
         {:ok, {cache, state}}
@@ -104,16 +104,12 @@ defmodule Cachex.Warmer do
             Cachex.put_many(cache, pairs, options)
         end
 
-        # fire again!
-        trigger()
+        # trigger the warming to happen again after the interval
+        :erlang.send_after(interval(), self(), :cachex_warmer)
 
         # repeat with the state
         {:noreply, persist_state}
       end
-
-      # Trigger a run to happen in the future.
-      defp trigger,
-        do: :erlang.send_after(interval(), self(), :cachex_warmer)
     end
   end
 end

--- a/lib/cachex/warmer.ex
+++ b/lib/cachex/warmer.ex
@@ -70,11 +70,11 @@ defmodule Cachex.Warmer do
       #
       # Initialization will trigger an initial cache warming, and store
       # the provided state for later to provide during further warming.
-      def init({cache, warmer(sync: sync, state: state)}) do
-        if sync do
-          handle_info(:cachex_warmer, {cache, state})
-        else
+      def init({cache, warmer(async: async, state: state)}) do
+        if async do
           send(self(), :cachex_warmer)
+        else
+          handle_info(:cachex_warmer, {cache, state})
         end
 
         {:ok, {cache, state}}

--- a/lib/cachex/warmer.ex
+++ b/lib/cachex/warmer.ex
@@ -88,7 +88,7 @@ defmodule Cachex.Warmer do
       # cache via `Cachex.put_many/3` if returns in a Tuple tagged with the
       # `:ok` atom. If `:ignore` is returned, nothing happens aside from
       # scheduling the next execution of the warming to occur on interval.
-      def handle_info(:cachex_warmer, {cache, state} = persist_state) do
+      def handle_info(:cachex_warmer, {cache, state} = process_state) do
         # execute, passing state
         case execute(state) do
           # no changes
@@ -108,7 +108,7 @@ defmodule Cachex.Warmer do
         :erlang.send_after(interval(), self(), :cachex_warmer)
 
         # repeat with the state
-        {:noreply, persist_state}
+        {:noreply, process_state}
       end
     end
   end

--- a/test/cachex/warmer_test.exs
+++ b/test/cachex/warmer_test.exs
@@ -43,6 +43,21 @@ defmodule Cachex.WarmerTest do
     assert Cachex.empty?(!cache)
   end
 
+  test "warmers which aren't blocking" do
+    # create a test warmer to pass to the cache
+    Helper.create_warmer(:async_warmer, 50, fn _ ->
+      :timer.sleep(3000)
+      {:ok, [{1, 1}]}
+    end)
+
+    # create a cache instance with a warmer
+    warmer = warmer(module: :async_warmer, sync: false)
+    cache = Helper.create_cache(warmers: [warmer])
+
+    # check that the key was not warmed
+    assert Cachex.get!(cache, 1) == nil
+  end
+
   test "providing warmers with states" do
     # create a test warmer to pass to the cache
     Helper.create_warmer(:state_warmer, 50, fn state ->

--- a/test/cachex/warmer_test.exs
+++ b/test/cachex/warmer_test.exs
@@ -51,7 +51,7 @@ defmodule Cachex.WarmerTest do
     end)
 
     # create a cache instance with a warmer
-    warmer = warmer(module: :async_warmer, sync: false)
+    warmer = warmer(module: :async_warmer, async: true)
     cache = Helper.create_cache(warmers: [warmer])
 
     # check that the key was not warmed


### PR DESCRIPTION
This fixes #280.

This adds a new option inside a `warmer` named `:async` which defaults to `false`. If you set this to `true`, the warmer startup will be asychronous and not block the cache startup.