### PR TITLE
Normalize courier calls to simplify :commit handling

### DIFF
--- a/lib/cachex/services/courier.ex
+++ b/lib/cachex/services/courier.ex
@@ -109,9 +109,29 @@ defmodule Cachex.Services.Courier do
   #
   # This will update all processes waiting for the result of the
   # specified task, and remove the task from the tracked state.
+  #
+  # Any processes waiting for the result will be given an `:ok`
+  # tag rather than a `:commit` tag, to make it possible to know
+  # which call to `fetch/4` actually loaded the backing value.
   def handle_info({:notify, key, result}, {cache, tasks}) do
-    for caller <- Map.get(tasks, key, []) do
-      GenServer.reply(caller, result)
+    callers =
+      tasks
+      |> Map.get(key, [])
+      |> Enum.reverse()
+
+    with [owner | listeners] = callers do
+      GenServer.reply(owner, result)
+
+      result =
+        if elem(result, 0) == :commit do
+          put_elem(result, 0, :ok)
+        else
+          result
+        end
+
+      for caller <- listeners do
+        GenServer.reply(caller, result)
+      end
     end
 
     {:noreply, {cache, Map.delete(tasks, key)}}

--- a/test/cachex/services/courier_test.exs
+++ b/test/cachex/services/courier_test.exs
@@ -44,11 +44,11 @@ defmodule Cachex.Services.CourierTest do
     # dispatch an arbitrary task from the current process
     result = Services.Courier.dispatch(cache, "my_key", task)
 
-    # check the forwarded task completed
-    assert_receive({:commit, "my_value"})
-
     # check the returned value
     assert result == {:commit, "my_value"}
+
+    # check the forwarded task completed
+    assert_receive({:ok, "my_value"})
 
     # check the key was placed in the table
     retrieved = Cachex.get(cache, "my_key")


### PR DESCRIPTION
This fixes #290.

I'm going to label this as a bug because I think it was unintended, and thus has now been fixed. Currently if you execute many `fetch/4` calls at the same time, it becomes impossible to know which of them actually wrote a value to the cache:

```elixir
iex(1)> Cachex.start(:test)
{:ok, #PID<0.528.0>}
iex(2)> my_func = fn _key -> :timer.sleep(2000) && "value" end
#Function<44.65746770/1 in :erl_eval.expr/5>
iex(3)> for _ <- 1..10 do
...(3)>   spawn(fn -> IO.inspect(Cachex.fetch(:test, "key", my_func)) end)
...(3)> end
[#PID<0.539.0>, #PID<0.540.0>, #PID<0.541.0>, #PID<0.542.0>, #PID<0.543.0>,
 #PID<0.544.0>, #PID<0.545.0>, #PID<0.547.0>, #PID<0.548.0>, #PID<0.549.0>]
{:commit, "value"}
{:commit, "value"}
{:commit, "value"}
{:commit, "value"}
{:commit, "value"}
{:commit, "value"}
{:commit, "value"}
{:commit, "value"}
{:commit, "value"}
{:commit, "value"}
```

This makes chaining calls on (such as then providing an expiration for your record) will run for every call instead of just the one which triggered the write. Ideally, this would run once in the process which was first to initiate the fetch. This PR fixes this to be the case, thus making the recommended expire pattern work correctly.

```elixir
iex(1)> Cachex.start(:test)
{:ok, #PID<0.528.0>}
iex(2)> my_func = fn _key -> :timer.sleep(2000) && "value" end
#Function<44.65746770/1 in :erl_eval.expr/5>
iex(3)> for _ <- 1..10 do
...(3)>   spawn(fn -> IO.inspect(Cachex.fetch(:test, "key", my_func)) end)
...(3)> end
[#PID<0.539.0>, #PID<0.540.0>, #PID<0.542.0>, #PID<0.543.0>, #PID<0.544.0>,
 #PID<0.545.0>, #PID<0.546.0>, #PID<0.547.0>, #PID<0.548.0>, #PID<0.549.0>]
{:commit, "value"}
{:ok, "value"}
{:ok, "value"}
{:ok, "value"}
{:ok, "value"}
{:ok, "value"}
{:ok, "value"}
{:ok, "value"}
{:ok, "value"}
{:ok, "value"}
```

With this in place, chained calls based on `:commit` will only fire in a single process instead of all of them. This is far better ergonomically, and also in terms of performance as we're not wasting many cache calls unnecessarily. 