### PR TITLE
fix missing warmer macro by importing Cachex.Spec

### DIFF
--- a/lib/cachex/warmer.ex
+++ b/lib/cachex/warmer.ex
@@ -62,6 +62,8 @@ defmodule Cachex.Warmer do
     quote location: :keep, generated: true do
       use GenServer
 
+      import Cachex.Spec
+
       # enforce the behaviour
       @behaviour Cachex.Warmer
 


### PR DESCRIPTION
While testing the async warmer functionality in the upstream version, I noticed it was raising an error

```
** (CompileError) lib/cachex/warmer.ex:73: cannot find or invoke local warmer/1 inside match. Only macros can be invoked in a match and they must be defined before their invocation. Called as: warmer(async: async, state: state)
```

fixed it by adding `import Cachex.Spec` to `lib/cachex/warmer.ex`