### PR TITLE
Fix up type spec for stats/2

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -1180,7 +1180,7 @@ defmodule Cachex do
       { :error, :stats_disabled }
 
   """
-  @spec stats(cache, Keyword.t()) :: {status, %{}}
+  @spec stats(cache, Keyword.t()) :: {status, map()}
   def stats(cache, options \\ []) when is_list(options),
     do: Router.call(cache, {:stats, [options]})
 


### PR DESCRIPTION
`%{}` means an empty map, `map()` means any map. This allows one to match against the result without dialyzer complaining.