### PR TITLE
Add a scheduled LRW policy for low memory use

### DIFF
--- a/lib/cachex/policy.ex
+++ b/lib/cachex/policy.ex
@@ -17,16 +17,6 @@ defmodule Cachex.Policy do
   """
   @callback hooks(Spec.limit()) :: [Spec.hook()]
 
-  @doc """
-  Returns an optional child spec to start for this policy.
-  """
-  @callback child_spec(Spec.limit()) :: Supervisor.Spec.spec()
-
-  @doc """
-  Returns the Supervisor strategy for this policy.
-  """
-  @callback strategy :: Supervisor.Spec.strategy()
-
   ##################
   # Implementation #
   ##################
@@ -38,21 +28,11 @@ defmodule Cachex.Policy do
       @behaviour Cachex.Policy
 
       @doc false
-      def child_spec(_limit),
-        do: []
-
-      @doc false
       def hooks(_limit),
         do: []
 
-      @doc false
-      def strategy,
-        do: :one_for_one
-
       # all can be overridden
-      defoverridable hooks: 1,
-                     strategy: 0,
-                     child_spec: 1
+      defoverridable hooks: 1
     end
   end
 end

--- a/lib/cachex/policy/lrw.ex
+++ b/lib/cachex/policy/lrw.ex
@@ -34,7 +34,7 @@ defmodule Cachex.Policy.LRW do
 
   @doc false
   # Backwards compatibility with < v3.5.x defaults
-  defdelegate hooks(limit), to: __MODULE__.Evented
+  defdelegate hooks(limit), to: __MODULE__.Scheduled
 
   #############
   # Algorithm #

--- a/lib/cachex/policy/lrw.ex
+++ b/lib/cachex/policy/lrw.ex
@@ -10,6 +10,7 @@ defmodule Cachex.Policy.LRW do
   There are several policies implemented using this algorithm:
 
   * `Cachex.Policy.LRW.Evented`
+  * `Cachex.Policy.LRW.Scheduled`
 
   Although the functions in this module are public, the way they function internally
   should be treated as private and subject to change at any point.

--- a/lib/cachex/policy/lrw.ex
+++ b/lib/cachex/policy/lrw.ex
@@ -51,7 +51,8 @@ defmodule Cachex.Policy.LRW do
   entries should be removed at once by this policy. This will default to a batch
   size of 100 entries at a time.
   """
-  def enforce_bounds(cache, limit() = limit) do
+  @spec enforce(Spec.cache(), Spec.limit()) :: :ok
+  def enforce(cache() = cache, limit() = limit) do
     limit(size: max_size, reclaim: reclaim, options: options) = limit
 
     batch_size =
@@ -169,5 +170,5 @@ defmodule Cachex.Policy.LRW do
     do: Informant.broadcast(state, {:clear, [[]]}, {:ok, offset})
 
   defp notify_worker(_offset, _state),
-    do: {:ok, 0}
+    do: :ok
 end

--- a/lib/cachex/policy/lrw/evented.ex
+++ b/lib/cachex/policy/lrw/evented.ex
@@ -87,7 +87,7 @@ defmodule Cachex.Policy.LRW.Evented do
   # able to cause a net gain in cache size (so removals are also ignored).
   def handle_notify(_message, {status, _value}, {cache, limit} = opts)
       when status not in @ignored,
-      do: LRW.enforce_bounds(cache, limit) && {:ok, opts}
+      do: LRW.enforce(cache, limit) && {:ok, opts}
 
   def handle_notify(_message, _result, opts),
     do: {:ok, opts}

--- a/lib/cachex/policy/lrw/evented.ex
+++ b/lib/cachex/policy/lrw/evented.ex
@@ -1,0 +1,106 @@
+defmodule Cachex.Policy.LRW.Evented do
+  @moduledoc """
+  Evented least recently written eviction policy for Cachex.
+
+  This module implements an evented LRW eviction policy for Cachex, using a hook
+  to listen for new key additions to a cache and enforcing bounds in a reactive
+  way. This policy enforces cache bounds and limits far more accurately than other
+  scheduled implementations, but comes at a higher memory cost (due to the message
+  passing between hooks).
+
+  The `:batch_size` option can be set in the limit options to dictate how many
+  entries should be removed at once by this policy. This will default to a batch
+  size of 100 entries at a time.
+
+  This eviction is relatively fast, and should keep the cache below bounds at most
+  times. Note that many writes in a very short amount of time can flood the cache,
+  but it should recover given a few seconds.
+  """
+  use Cachex.Hook
+  use Cachex.Policy
+
+  # import macros
+  import Cachex.Spec
+
+  # add internal aliases
+  alias Cachex.Policy.LRW
+
+  # actions which didn't trigger a write
+  @ignored [:error, :ignored]
+
+  ####################
+  # Policy Behaviour #
+  ####################
+
+  @doc """
+  Retrieves a list of hooks required to run against this policy.
+  """
+  @spec hooks(Spec.limit()) :: [Spec.hook()]
+  def hooks(limit),
+    do: [hook(module: __MODULE__, state: limit)]
+
+  ######################
+  # Hook Configuration #
+  ######################
+
+  @doc """
+  Returns the actions this policy should listen on.
+
+  This returns as a `MapSet` to optimize the lookups
+  on actions to O(n) in the broadcasting algorithm.
+  """
+  @spec actions :: [atom]
+  def actions,
+    do: [
+      :put,
+      :decr,
+      :incr,
+      :fetch,
+      :update,
+      :put_many,
+      :get_and_update
+    ]
+
+  @doc """
+  Returns the provisions this policy requires.
+  """
+  @spec provisions :: [atom]
+  def provisions,
+    do: [:cache]
+
+  ####################
+  # Server Callbacks #
+  ####################
+
+  @doc false
+  # Initializes this policy using the limit being enforced.
+  #
+  # The maximum size is stored in the state, alongside the pre-calculated
+  # number to trim down to. The batch size to use when removing records is
+  # also configurable via the provided options.
+  def init(limit() = limit),
+    do: {:ok, {nil, limit}}
+
+  @doc false
+  # Handles notification of a cache action.
+  #
+  # This will check if the action can modify the size of the cache, and if so will
+  # execute the boundary enforcement to trim the size as needed.
+  #
+  # Note that this will ignore error results and only operates on actions which are
+  # able to cause a net gain in cache size (so removals are also ignored).
+  def handle_notify(_message, {status, _value}, {cache, limit} = opts)
+      when status not in @ignored,
+      do: LRW.enforce_bounds(cache, limit) && {:ok, opts}
+
+  def handle_notify(_message, _result, opts),
+    do: {:ok, opts}
+
+  @doc false
+  # Receives a provisioned cache instance.
+  #
+  # The provided cache is then stored in the cache and used for cache calls going
+  # forwards, in order to skip the lookups inside the cache overseer for performance.
+  def handle_provision({:cache, cache}, {_cache, limit}),
+    do: {:ok, {cache, limit}}
+end

--- a/lib/cachex/policy/lrw/scheduled.ex
+++ b/lib/cachex/policy/lrw/scheduled.ex
@@ -73,7 +73,7 @@ defmodule Cachex.Policy.LRW.Scheduled do
   # This will execute a bounds check on a cache and schedule a new check.
   def handle_info(:policy_check, {cache, limit} = opts) do
     unless is_nil(cache) do
-      LRW.enforce_bounds(cache, limit)
+      LRW.enforce(cache, limit)
     end
 
     schedule(limit) && {:noreply, opts}

--- a/lib/cachex/services.ex
+++ b/lib/cachex/services.ex
@@ -59,7 +59,6 @@ defmodule Cachex.Services do
     |> Enum.concat(incubator_spec(cache))
     |> Enum.concat(courier_spec(cache))
     |> Enum.concat(janitor_spec(cache))
-    |> Enum.concat(limit_spec(cache))
   end
 
   @doc """
@@ -147,30 +146,6 @@ defmodule Cachex.Services do
         start: {Services.Janitor, :start_link, [cache]}
       }
     ]
-
-  # Creates any require limit specifications for the supervision tree.
-  #
-  # This will rarely be used in the out-of-the-box experience, it's mainly
-  # provided for use in custom limit implementations by developers.
-  defp limit_spec(cache(limit: limit(size: nil))),
-    do: []
-
-  defp limit_spec(cache(limit: limit(policy: policy) = limit)) do
-    case apply(policy, :child_spec, [limit]) do
-      [] ->
-        []
-
-      cs ->
-        [
-          %{
-            id: Supervisor,
-            start:
-              {Supervisor, :start_link,
-               [cs, [strategy: apply(policy, :strategy, [])]]}
-          }
-        ]
-    end
-  end
 
   # Creates the required Locksmith queue specification for a cache.
   #

--- a/test/cachex/policy/lrw/evented_test.exs
+++ b/test/cachex/policy/lrw/evented_test.exs
@@ -1,4 +1,4 @@
-defmodule Cachex.Policy.LRWTest do
+defmodule Cachex.Policy.LRW.EventedTest do
   use CachexCase
 
   # This test just ensures that there are no artificial limits placed on a cache

--- a/test/cachex/policy/lrw/scheduled_test.exs
+++ b/test/cachex/policy/lrw/scheduled_test.exs
@@ -1,4 +1,4 @@
-defmodule Cachex.Policy.LRW.EventedTest do
+defmodule Cachex.Policy.LRW.ScheduledTest do
   use CachexCase
 
   # This test just ensures that there are no artificial limits placed on a cache
@@ -36,9 +36,9 @@ defmodule Cachex.Policy.LRW.EventedTest do
     limit =
       limit(
         size: 100,
-        policy: Cachex.Policy.LRW.Evented,
+        policy: Cachex.Policy.LRW.Scheduled,
         reclaim: 0.75,
-        options: [batch_size: 25]
+        options: [batch_size: 25, frequency: 100]
       )
 
     # create a cache with a max size
@@ -112,9 +112,9 @@ defmodule Cachex.Policy.LRW.EventedTest do
     limit =
       limit(
         size: 100,
-        policy: Cachex.Policy.LRW.Evented,
+        policy: Cachex.Policy.LRW.Scheduled,
         reclaim: 0.3,
-        options: [batch_size: -1]
+        options: [batch_size: -1, frequency: 100]
       )
 
     # create a cache with a max size

--- a/test/cachex/policy_test.exs
+++ b/test/cachex/policy_test.exs
@@ -2,10 +2,7 @@ defmodule Cachex.PolicyTest do
   use CachexCase
 
   test "default policy implementations" do
-    # validate each default implementation provided by __using__
-    assert __MODULE__.DefaultPolicy.strategy() == :one_for_one
     assert __MODULE__.DefaultPolicy.hooks(limit()) == []
-    assert __MODULE__.DefaultPolicy.child_spec(limit()) == []
   end
 
   defmodule DefaultPolicy,

--- a/test/cachex/services_test.exs
+++ b/test/cachex/services_test.exs
@@ -27,31 +27,6 @@ defmodule Cachex.ServicesTest do
            ] = Services.cache_spec(cache)
   end
 
-  test "generating cache limit specifications" do
-    # generate the test cache state with a limit attached
-    name =
-      Helper.create_cache(limit: limit(size: 10, policy: __MODULE__.TestPolicy))
-
-    cache = Services.Overseer.retrieve(name)
-
-    # validate the services
-    assert [
-             %{id: Eternal, start: {Eternal, _, _}},
-             %{
-               id: Services.Locksmith.Queue,
-               start: {Services.Locksmith.Queue, _, _}
-             },
-             %{id: Services.Informant, start: {Services.Informant, _, _}},
-             %{id: Services.Incubator, start: {Services.Incubator, _, _}},
-             %{id: Services.Courier, start: {Services.Courier, _, _}},
-             %{id: Services.Janitor, start: {Services.Janitor, _, _}},
-             %{
-               id: Supervisor,
-               start: {Supervisor, _, [[%{id: __MODULE__.TestPolicy}], _]}
-             }
-           ] = Services.cache_spec(cache)
-  end
-
   test "skipping cache janitor specifications" do
     # generate the test cache state with the Janitor disabled
     name = Helper.create_cache(expiration: expiration(interval: nil))
@@ -78,15 +53,5 @@ defmodule Cachex.ServicesTest do
     # validate the service locations
     assert Services.locate(cache, Services.Courier) != nil
     assert Services.locate(cache, Services.Janitor) == nil
-  end
-
-  defmodule TestPolicy do
-    use Cachex.Policy
-
-    def child_spec(_limit),
-      do: [%{id: __MODULE__, start: {__MODULE__, :start_link, []}}]
-
-    def start_link,
-      do: :ignore
   end
 end


### PR DESCRIPTION
This closes #303 and #300. 

This PR introduces a new implementation of the LRW policy which avoids the need for message passing in hooks. It operates on a (configurable) schedule to check the cache bounds. As such, it uses less memory but might have a larger delay on reclaiming space - pick your poison.

I moved `Cachex.Policy.LRW` into `Cachex.Policy.LRW.Evented` and delegated through to save the existing defaults, or people referencing that module already. The LRW logic stays inside `Cachex.Policy.LRW`, because it's used in both places. It will also be used if we ever get around to #305. 

I *think* I want to change the default away from the evented version to the scheduled version, but I need to think more on this. Not only is the policy server more efficient, it will actually help throughput of your cache (because it's not pinging the LRW hook on every write). Given that the check is once per second, it seems like it should be hard to notice the change for most use cases.

I'm not sure I like `enforce_bounds` as a public name, so need to think about that. Even something like `prune/2` might be better as a public name. I also removed some junk in the policy space which was unused in favour of just using hooks going forward. I originally had bigger plans, which is why the spec stuff was in there - but at this point I think it's just bloat. 