### PR TITLE
Allow expiration to be inline from inside fetch functions

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -643,6 +643,12 @@ defmodule Cachex do
   cache. If you return a value which does not fit this structure, it
   will be assumed that you are committing the value.
 
+  As of Cachex v3.6, you can also provide a third element in a `:commit`
+  Tuple, to allow passthrough of options from within your fallback. The
+  options supported in this list match the options you can provide to a
+  call of `put/4`. An example is the `:ttl` option to set an expiration
+  from directly inside your fallback.
+
   If a fallback function has an arity of 1, the requested entry key
   will be passed through to allow for contextual computation. If a
   function has an arity of 2, the `:provide` option from the global
@@ -671,6 +677,11 @@ defmodule Cachex do
       ...>   { :commit, String.reverse(key) }
       ...> end)
       { :commit, "yek_gnissim" }
+
+      iex> Cachex.fetch(:my_cache, "missing_key_ttl", fn(key) ->
+      ...>   { :commit, String.reverse(key), ttl: :timer.seconds(60) }
+      ...> end)
+      { :commit, "ltt_yek_gnissim", [ttl: 60000] }
 
   """
   @spec fetch(cache, any, function | nil, Keyword.t()) ::
@@ -713,7 +724,9 @@ defmodule Cachex do
   This function accepts the same return syntax as fallback functions, in that if
   you return a Tuple of the form `{ :ignore, value }`, the value is returned from
   the call but is not written to the cache. You can use this to abandon writes
-  which began eagerly (for example if a key is actually missing).
+  which began eagerly (for example if a key is actually missing)
+
+  See the `fetch/4` documentation for more information on return formats.
 
   ## Examples
 

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -685,7 +685,7 @@ defmodule Cachex do
 
   """
   @spec fetch(cache, any, function | nil, Keyword.t()) ::
-          {status | :commit | :ignore, any}
+          {status | :commit | :ignore, any} | {:commit, any, any}
   def fetch(cache, key, fallback \\ nil, options \\ []) when is_list(options) do
     Overseer.enforce cache do
       case fallback || fallback(cache(cache, :fallback), :default) do

--- a/lib/cachex/actions.ex
+++ b/lib/cachex/actions.ex
@@ -17,6 +17,29 @@ defmodule Cachex.Actions do
   ##############
 
   @doc """
+  Normalizes a value into a Courier-friendly tagged Tuple.
+
+  If the value is tagged with `:commit`, `:ignore` or `:error`,
+  it will be left alone; otherwise it will be wrapped and treated
+  as a `:commit` Tuple.
+  """
+  def normalize_commit(value) do
+    case value do
+      {:error, _value} ->
+        value
+
+      {:commit, _value} ->
+        value
+
+      {:ignore, _value} ->
+        value
+
+      raw_value ->
+        {:commit, raw_value}
+    end
+  end
+
+  @doc """
   Retrieves an entry from a cache.
 
   If the entry does not exist, a `nil` value will be returned. Likewise
@@ -73,33 +96,4 @@ defmodule Cachex.Actions do
 
   def write_op(_tag),
     do: :update
-
-  ##########
-  # Macros #
-  ##########
-
-  @doc """
-  Normalizes a value into a Courier-friendly tagged Tuple.
-
-  If the value is tagged with `:commit`, `:ignore` or `:error`,
-  it will be left alone; otherwise it will be wrapped and treated
-  as a `:commit` Tuple.
-  """
-  defmacro normalize_commit(value) do
-    quote bind_quoted: [value: value] do
-      case value do
-        {:error, _value} ->
-          value
-
-        {:commit, _value} ->
-          value
-
-        {:ignore, _value} ->
-          value
-
-        raw_value ->
-          {:commit, raw_value}
-      end
-    end
-  end
 end

--- a/lib/cachex/actions.ex
+++ b/lib/cachex/actions.ex
@@ -17,18 +17,21 @@ defmodule Cachex.Actions do
   ##############
 
   @doc """
-  Normalizes a value into a Courier-friendly tagged Tuple.
+  Formats a fetched value into a Courier compatible tuple.
 
   If the value is tagged with `:commit`, `:ignore` or `:error`,
   it will be left alone; otherwise it will be wrapped and treated
   as a `:commit` Tuple.
   """
-  def normalize_commit(value) do
+  def format_fetch_value(value) do
     case value do
       {:error, _value} ->
         value
 
       {:commit, _value} ->
+        value
+
+      {:commit, _value, _options} ->
         value
 
       {:ignore, _value} ->
@@ -38,6 +41,18 @@ defmodule Cachex.Actions do
         {:commit, raw_value}
     end
   end
+
+  @doc """
+  Normalizes a commit formatted fetch value.
+
+  This is simply compatibility for the options addition in v3.5, without
+  breaking the previous versions of this library.
+  """
+  def normalize_commit({:commit, value}),
+    do: {:commit, value, []}
+
+  def normalize_commit(value),
+    do: value
 
   @doc """
   Retrieves an entry from a cache.

--- a/lib/cachex/actions/get_and_update.ex
+++ b/lib/cachex/actions/get_and_update.ex
@@ -31,18 +31,19 @@ defmodule Cachex.Actions.GetAndUpdate do
     Locksmith.transaction(cache, [key], fn ->
       {_label, value} = Cachex.get(cache, key, [])
 
-      normalized =
+      formatted =
         value
         |> update_fun.()
-        |> Actions.normalize_commit()
+        |> Actions.format_fetch_value()
 
       operation = Actions.write_op(value)
+      normalized = Actions.normalize_commit(formatted)
 
-      with {:commit, new_value} <- normalized do
-        apply(Cachex, operation, [cache, key, new_value, []])
+      with {:commit, new_value, options} <- normalized do
+        apply(Cachex, operation, [cache, key, new_value, options])
       end
 
-      normalized
+      formatted
     end)
   end
 end

--- a/lib/cachex/actions/get_and_update.ex
+++ b/lib/cachex/actions/get_and_update.ex
@@ -5,10 +5,10 @@ defmodule Cachex.Actions.GetAndUpdate do
   # This command is simply sugar, but is common enough that it deserved an explicit
   # implementation inside the API. It does take care of the transactional context
   # of the get/update semantics though, so it's potentially non-obvious.
+  alias Cachex.Actions
   alias Cachex.Services.Locksmith
 
   # add needed imports
-  import Cachex.Actions
   import Cachex.Spec
 
   ##############
@@ -34,10 +34,12 @@ defmodule Cachex.Actions.GetAndUpdate do
       normalized =
         value
         |> update_fun.()
-        |> normalize_commit
+        |> Actions.normalize_commit()
+
+      operation = Actions.write_op(value)
 
       with {:commit, new_value} <- normalized do
-        apply(Cachex, write_op(value), [cache, key, new_value, []])
+        apply(Cachex, operation, [cache, key, new_value, []])
       end
 
       normalized

--- a/lib/cachex/services/courier.ex
+++ b/lib/cachex/services/courier.ex
@@ -14,10 +14,10 @@ defmodule Cachex.Services.Courier do
   use GenServer
 
   # import spec macros
-  import Cachex.Actions
   import Cachex.Spec
 
   # add some aliases
+  alias Cachex.Actions
   alias Cachex.Actions.Put
   alias Cachex.ExecutionError
 
@@ -86,7 +86,7 @@ defmodule Cachex.Services.Courier do
                   }
               end
 
-            normalized = normalize_commit(result)
+            normalized = Actions.normalize_commit(result)
 
             with {:commit, val} <- normalized do
               Put.execute(cache, key, val, const(:notify_false))

--- a/lib/cachex/services/courier.ex
+++ b/lib/cachex/services/courier.ex
@@ -86,13 +86,14 @@ defmodule Cachex.Services.Courier do
                   }
               end
 
-            normalized = Actions.normalize_commit(result)
+            formatted = Actions.format_fetch_value(result)
+            normalized = Actions.normalize_commit(formatted)
 
-            with {:commit, val} <- normalized do
-              Put.execute(cache, key, val, const(:notify_false))
+            with {:commit, val, options} <- normalized do
+              Put.execute(cache, key, val, [const(:notify_false) | options])
             end
 
-            send(parent, {:notify, key, normalized})
+            send(parent, {:notify, key, formatted})
           end)
 
           [caller]

--- a/lib/cachex/services/courier.ex
+++ b/lib/cachex/services/courier.ex
@@ -124,10 +124,15 @@ defmodule Cachex.Services.Courier do
       GenServer.reply(owner, result)
 
       result =
-        if elem(result, 0) == :commit do
-          put_elem(result, 0, :ok)
-        else
-          result
+        case result do
+          {:commit, value, _} ->
+            {:ok, value}
+
+          {:commit, value} ->
+            {:ok, value}
+
+          value ->
+            value
         end
 
       for caller <- listeners do

--- a/test/cachex/actions/fetch_test.exs
+++ b/test/cachex/actions/fetch_test.exs
@@ -138,6 +138,27 @@ defmodule Cachex.Actions.FetchTest do
     end
   end
 
+  test "fetching and setting an expiration on a key from a fallback" do
+    # create a test cache
+    cache = Helper.create_cache()
+
+    # create a fallback with an expiration
+    purged = [ttl: 60000]
+    fb_opt = &{:commit, String.reverse(&1), purged}
+
+    # fetch our key using our fallback
+    result = Cachex.fetch(cache, "key", fb_opt)
+
+    # verify fetching an existing key
+    assert(result == {:commit, "yek", purged})
+
+    # fetch back the expiration of the key
+    expiration = Cachex.ttl!(cache, "key")
+
+    # check we have a set expiration
+    assert_in_delta(expiration, 60000, 250)
+  end
+
   # This test verifies that this action is correctly distributed across
   # a cache cluster, instead of just the local node. We're not concerned
   # about the actual behaviour here, only the routing of the action.

--- a/test/cachex/actions_test.exs
+++ b/test/cachex/actions_test.exs
@@ -115,28 +115,47 @@ defmodule Cachex.ActionsTest do
   # This test just ensures that we correctly convert return values to either a
   # :commit Tuple or an :ignore Tuple. We also make sure to verify that the default
   # behaviour is a :commit Tuple for backwards compatibility.
-  test "normalizing commit/ignore return values" do
+  test "formatting commit/ignore return values" do
     # define our base Tuples to test against
     tuple1 = {:commit, true}
     tuple2 = {:ignore, true}
     tuple3 = {:error, true}
+    tuple4 = {:commit, true, []}
 
     # define our base value
     value1 = true
 
-    # normalize all values
-    result1 = Cachex.Actions.normalize_commit(tuple1)
-    result2 = Cachex.Actions.normalize_commit(tuple2)
-    result3 = Cachex.Actions.normalize_commit(tuple3)
-    result4 = Cachex.Actions.normalize_commit(value1)
+    # format all values
+    result1 = Cachex.Actions.format_fetch_value(tuple1)
+    result2 = Cachex.Actions.format_fetch_value(tuple2)
+    result3 = Cachex.Actions.format_fetch_value(tuple3)
+    result4 = Cachex.Actions.format_fetch_value(tuple4)
+    result5 = Cachex.Actions.format_fetch_value(value1)
 
     # the first three should persist
     assert(result1 == tuple1)
     assert(result2 == tuple2)
     assert(result3 == tuple3)
+    assert(result4 == tuple4)
 
     # the value should be converted to the first
-    assert(result4 == tuple1)
+    assert(result5 == tuple1)
+  end
+
+  # Simple test to ensure that commit normalization correctly assigns
+  # options to a commit tuple without, and maintains those with.
+  test "normalizing formatted :commit values" do
+    # define our base Tuples to test against
+    tuple1 = {:commit, true}
+    tuple2 = {:commit, true, []}
+
+    # normalize all values
+    result1 = Cachex.Actions.normalize_commit(tuple1)
+    result2 = Cachex.Actions.normalize_commit(tuple2)
+
+    # both should have options
+    assert(result1 == tuple2)
+    assert(result2 == tuple2)
   end
 
   # This test just provides basic coverage of the write_op function, by using

--- a/test/cachex/services/courier_test.exs
+++ b/test/cachex/services/courier_test.exs
@@ -28,7 +28,8 @@ defmodule Cachex.Services.CourierTest do
 
     # define our task function
     task = fn ->
-      :timer.sleep(250) && "my_value"
+      :timer.sleep(250)
+      {:commit, "my_value", ttl: :timer.seconds(60)}
     end
 
     # start a new cache
@@ -44,10 +45,10 @@ defmodule Cachex.Services.CourierTest do
     # dispatch an arbitrary task from the current process
     result = Services.Courier.dispatch(cache, "my_key", task)
 
-    # check the returned value
-    assert result == {:commit, "my_value"}
+    # check the returned value with the options set
+    assert result == {:commit, "my_value", [ttl: 60000]}
 
-    # check the forwarded task completed
+    # check the forwarded task completed (no options)
     assert_receive({:ok, "my_value"})
 
     # check the key was placed in the table


### PR DESCRIPTION
Fixes #304!

This PR introduces a third element in the return value from a fetch function, allowing you to provide generated options (including `:ttl`). This removes the clunky `with` wrapping for commits which has confused many people in the past.

Updated documentation and examples on how to use the new syntax too. Waiting for feedback before merge!

Some relevant issues:

* #304 
* #307 
* #288 
* #282 
* #253 
* #195 

(So many, sorry I didn't address this properly in the past 😞)