### PR TITLE
Adds the {:error, :no_cache} case to function doc to be clear

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -710,6 +710,8 @@ defmodule Cachex do
       iex> Cachex.get(:my_cache, "missing_key")
       { :ok, nil }
 
+      iex> Cachex.get(:missing_cache, "missing_key")
+      { :error, :no_cache }
   """
   @spec get(cache, any, Keyword.t()) :: {atom, any}
   def get(cache, key, options \\ []) when is_list(options),


### PR DESCRIPTION
We ran into this in production and the developers that wrote the code using Cachex did not know that 
get could return anything other than `{:ok, "value"}` or `{:ok, nil}`
When looking at the docs for the function call I can see why.
This may be helpful for others using this lib in their code.