### PR TITLE
Correctly terminate distributed caches

### DIFF
--- a/lib/cachex/services/janitor.ex
+++ b/lib/cachex/services/janitor.ex
@@ -132,8 +132,7 @@ defmodule Cachex.Services.Janitor do
 
   # Schedules a check to occur after the designated interval. Once scheduled,
   # returns the state - this is just sugar for pipelining with a state.
-  defp schedule_check(
-         cache(expiration: expiration(interval: interval)) = cache
-       ),
-       do: :erlang.send_after(interval, self(), :ttl_check) && cache
+  defp schedule_check(cache(expiration: expiration(interval: interval)) = cache) do
+    :erlang.send_after(interval, self(), :ttl_check) && cache
+  end
 end

--- a/test/lib/cachex_case/helper.ex
+++ b/test/lib/cachex_case/helper.ex
@@ -47,6 +47,8 @@ defmodule CachexCase.Helper do
 
     # stop all children on exit, even though it's automatic
     TestHelper.on_exit("stop #{name} children", fn ->
+      Supervisor.stop(name)
+
       nodes
       |> List.delete(node())
       |> LocalCluster.stop_nodes()

--- a/test/lib/cachex_case/helper.ex
+++ b/test/lib/cachex_case/helper.ex
@@ -45,10 +45,11 @@ defmodule CachexCase.Helper do
         [name, [nodes: nodes] ++ args]
       )
 
+    # cleanup the cache on exit
+    TestHelper.delete_on_exit(name)
+
     # stop all children on exit, even though it's automatic
     TestHelper.on_exit("stop #{name} children", fn ->
-      Supervisor.stop(name)
-
       nodes
       |> List.delete(node())
       |> LocalCluster.stop_nodes()


### PR DESCRIPTION
Fixes #318.

Something changed in Elixir v1.15 which started showing many errors. Initially I thought it was some bug in the newer version, but it turns out the older versions were just masking an error in tests. This corrects this issue, which was just leaving some unused services around during tests.