### PR TITLE
Allow warmers to trigger hooks

### DIFF
--- a/lib/cachex/actions/warm.ex
+++ b/lib/cachex/actions/warm.ex
@@ -28,7 +28,7 @@ defmodule Cachex.Actions.Warm do
   def execute(cache() = cache, options) do
     mods = Keyword.get(options, :modules, nil)
     parent = Services.locate(cache, Services.Incubator)
-    children = Supervisor.which_children(parent)
+    children = if parent, do: Supervisor.which_children(parent), else: []
 
     handlers =
       for {mod, pid, _, _} <- children, mods == nil or mod in mods do


### PR DESCRIPTION
A) Sorry that this didnt start with an issue - feel free to close this and we can move any discussion over there, but I put together this PR as a POC to ensure that this solved our issue on our application side

B) The issue we were running into is that we wanted to use a Hook to react to when a Warmer ran and found that Warmers did not trigger hooks - this issue seems to be caused by the fact that warmers are initialized with a cache spec before the hooks are associated to their pids, so the notification filters these out thinking that they are not running.

This PR addresses that particular issue by having the warmer call `put_many` with just the cache name instead of the cache spec so that the current state will always be used to avoid any possibility of a race condition between the warmer running and the hooks starting and being added to the Overseer's cache state

Additionally, this PR rearranges the lifecycle of the warmer a bit to ensure that the first run will happen after any hooks have been started / attached so that notifications will not be missed

Please let me know if there are any questions / comments / changes you would like to see - and thank you for all of the work you do by maintaining this project