### PR TITLE
Add Cachex.warm/2 to allow manual cache warming

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -98,7 +98,8 @@ defmodule Cachex do
     touch: [2, 3],
     transaction: [3, 4],
     ttl: [2, 3],
-    update: [3, 4]
+    update: [3, 4],
+    warm: [1, 2]
   ]
 
   ##############
@@ -1367,6 +1368,37 @@ defmodule Cachex do
   @spec update(cache, any, any, Keyword.t()) :: {status, any}
   def update(cache, key, value, options \\ []) when is_list(options),
     do: Router.call(cache, {:update, [key, value, options]})
+
+  @doc """
+  Triggers a manual warming in a cache.
+
+  This allows for manual warming of a cache in situations where
+  you already know the backing state has been updated. The return
+  value of this function will contain the list of modules which
+  were warmed as a result of this call.
+
+  ## Options
+
+    * `:modules`
+
+      An optional list of modules to warm, acting as a whitelist. The default
+      behaviour of this function is to trigger warming in all modules.
+
+  ## Examples
+
+      iex> Cachex.warm(:my_cache)
+      { :ok, [MyWarmer] }
+
+      iex> Cachex.warm(:my_cache, modules: [MyWarmer])
+      { :ok, [MyWarmer] }
+
+      iex> Cachex.warm(:my_cache, modules: [])
+      { :ok, [] }
+
+  """
+  @spec warm(cache, Keyword.t()) :: {status, [atom()]}
+  def warm(cache, options \\ []),
+    do: Router.call(cache, {:warm, [options]})
 
   ###############
   # Private API #

--- a/lib/cachex/actions/warm.ex
+++ b/lib/cachex/actions/warm.ex
@@ -1,0 +1,40 @@
+defmodule Cachex.Actions.Warm do
+  @moduledoc false
+  # Command module to trigger manual cache warming.
+  #
+  # The only reason to call this command is the case in which you already
+  # know the backing state of your cache has been updated and you need to
+  # immediately refresh your warmed entries.
+  alias Cachex.Services
+
+  # we need our imports
+  import Cachex.Spec
+
+  ##############
+  # Public API #
+  ##############
+
+  @doc """
+  Triggers a manual warming in a cache.
+
+  The warmers are fetched back out of the supervision tree, by calling out
+  to our services module. This allows us to avoid having to track any special
+  state in order to support manual warming.
+
+  You can provide a `:modules` option to restrict the warming to a specific
+  set of warmer modules. The list of modules which had a warming triggered will
+  be returned in the result of this call.
+  """
+  def execute(cache() = cache, options) do
+    mods = Keyword.get(options, :modules, nil)
+    parent = Services.locate(cache, Services.Incubator)
+    children = Supervisor.which_children(parent)
+
+    handlers =
+      for {mod, pid, _, _} <- children, mods == nil or mod in mods do
+        send(pid, :cachex_warmer) && mod
+      end
+
+    {:ok, handlers}
+  end
+end

--- a/lib/cachex/router.ex
+++ b/lib/cachex/router.ex
@@ -187,8 +187,7 @@ defmodule Cachex.Router do
     :purge,
     :reset,
     :size,
-    :stats,
-    :warm
+    :stats
   ]
 
   # Provides handling of cross-node actions distributed over remote nodes.
@@ -247,7 +246,7 @@ defmodule Cachex.Router do
   end
 
   # actions which always run locally
-  @local_actions [:dump, :inspect, :load]
+  @local_actions [:dump, :inspect, :load, :warm]
 
   # Provides handling of `:inspect` operations.
   #

--- a/lib/cachex/router.ex
+++ b/lib/cachex/router.ex
@@ -187,7 +187,8 @@ defmodule Cachex.Router do
     :purge,
     :reset,
     :size,
-    :stats
+    :stats,
+    :warm
   ]
 
   # Provides handling of cross-node actions distributed over remote nodes.

--- a/test/cachex_test.exs
+++ b/test/cachex_test.exs
@@ -177,7 +177,7 @@ defmodule CachexTest do
     assert(is_even(length(definitions)))
 
     # verify the size to cause errors on addition/removal
-    assert(length(definitions) == 152)
+    assert(length(definitions) == 156)
 
     # validate all definitions
     for {name, arity} <- definitions do


### PR DESCRIPTION
This fixes #299.

This PR will add a new `Cachex.warm/2` which performs a lookup on `Cachex.Incubator` to locate all child warmers and notify them to warm immediately. You can optionally provide the `:modules` option to restrict to a specific set of cache warmers. The list of modules which actually had warming triggered is returned.

