### PR TITLE
Rename transactional to transactions in options structs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ The second and third arguments are both optional and represent cache and server 
 |       hooks      |     list of `hook()`     |        A list of execution hooks to listen on cache actions.       |
 |       limit      |    a `limit()` record    |    An integer or Limit struct to define the bounds of this cache.  |
 |       stats      |          boolean         |         Whether to track statistics for this cache or not.         |
-|   transactional  |          boolean         |           Whether to turn on transactions at cache start.          |
+|   transactions   |          boolean         |           Whether to turn on transactions at cache start.          |
 |      warmers     |    list of `warmer()`    |           A list of cache warmers to enable on the cache.          |
 
 ## Main Interface

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -291,7 +291,7 @@ defmodule Cachex do
           iex> Cachex.start_link(:my_cache, [ stats: true ])
           { :ok, _pid }
 
-    * `:transactional`
+    * `:transactions`
 
       This option will specify whether this cache should have transactions and row
       locking enabled from cache startup. Please note that even if this is false,
@@ -1318,14 +1318,14 @@ defmodule Cachex do
       when is_function(operation, 1) and is_list(keys) and is_list(options) do
     Overseer.enforce cache do
       trans_cache =
-        case cache(cache, :transactional) do
+        case cache(cache, :transactions) do
           true ->
             cache
 
           false ->
             cache
             |> cache(:name)
-            |> Overseer.update(&cache(&1, transactional: true))
+            |> Overseer.update(&cache(&1, transactions: true))
         end
 
       Router.call(trans_cache, {:transaction, [keys, operation, options]})

--- a/lib/cachex/options.ex
+++ b/lib/cachex/options.ex
@@ -25,7 +25,7 @@ defmodule Cachex.Options do
     :fallback,
     :compressed,
     :expiration,
-    :transactional,
+    :transactions,
     :warmers
   ]
 
@@ -325,12 +325,12 @@ defmodule Cachex.Options do
 
   # Configures a cache based on transaction flags.
   #
-  # This will simply configure the `:transactional` field in the cache
+  # This will simply configure the `:transactions` field in the cache
   # record and return the modified record with the flag attached.
-  defp parse_type(:transactional, cache, options),
+  defp parse_type(:transactions, cache, options),
     do:
       cache(cache,
-        transactional: get(options, :transactional, &is_boolean/1, false)
+        transactions: get(options, :transactions, &is_boolean/1, false)
       )
 
   # Configures any warmers assigned to the cache.

--- a/lib/cachex/services/locksmith.ex
+++ b/lib/cachex/services/locksmith.ex
@@ -156,7 +156,7 @@ defmodule Cachex.Services.Locksmith do
   our ETS writes are atomic and so do not require a lock.
   """
   @spec write(Cachex.Spec.cache(), any, (-> any)) :: any
-  def write(cache(transactional: false), _keys, fun),
+  def write(cache(transactions: false), _keys, fun),
     do: fun.()
 
   def write(cache() = cache, keys, fun) do

--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -35,7 +35,7 @@ defmodule Cachex.Spec do
             limit: limit,
             nodes: [atom],
             ordered: boolean,
-            transactional: boolean,
+            transactions: boolean,
             warmers: [warmer]
           )
 
@@ -126,7 +126,7 @@ defmodule Cachex.Spec do
     limit: nil,
     nodes: [],
     ordered: false,
-    transactional: false,
+    transactions: false,
     warmers: []
 
   @doc """

--- a/test/cachex/actions/inspect_test.exs
+++ b/test/cachex/actions/inspect_test.exs
@@ -138,7 +138,7 @@ defmodule Cachex.Actions.InspectTest do
     # update the state to have a different setting
     state2 =
       Services.Overseer.update(cache, fn state ->
-        cache(state, transactional: true)
+        cache(state, transactions: true)
       end)
 
     # retrieve the state via inspection

--- a/test/cachex/actions/transaction_test.exs
+++ b/test/cachex/actions/transaction_test.exs
@@ -10,7 +10,7 @@ defmodule Cachex.Actions.TransactionTest do
   # the value for the first time.
   test "executing a transaction is atomic" do
     # create a test cache
-    cache = Helper.create_cache(transactional: true)
+    cache = Helper.create_cache(transactions: true)
 
     # spawn a transaction to increment a key
     spawn(fn ->
@@ -67,7 +67,7 @@ defmodule Cachex.Actions.TransactionTest do
     state1 = Services.Overseer.retrieve(cache)
 
     # verify transactions are disabled
-    assert(cache(state1, :transactional) == false)
+    assert(cache(state1, :transactions) == false)
 
     # execute a transactions
     Cachex.transaction(cache, [], & &1)
@@ -76,7 +76,7 @@ defmodule Cachex.Actions.TransactionTest do
     state2 = Services.Overseer.retrieve(cache)
 
     # verify transactions are now enabled
-    assert(cache(state2, :transactional) == true)
+    assert(cache(state2, :transactions) == true)
   end
 
   # This test verifies that this action is correctly distributed across

--- a/test/cachex/options_test.exs
+++ b/test/cachex/options_test.exs
@@ -370,18 +370,18 @@ defmodule Cachex.OptionsTest do
   # a cache has them enabled or disabled. This is simply checking whether the flag
   # is set to true or false, and the default. We also verify that the transaction
   # locksmith has its name set inside the returned state.
-  test "parsing :transactional flags" do
+  test "parsing :transactions flags" do
     # grab a cache name
     name = Helper.create_name()
 
     # parse our values as options
-    {:ok, cache(transactional: trans1)} =
-      Cachex.Options.parse(name, transactional: true)
+    {:ok, cache(transactions: trans1)} =
+      Cachex.Options.parse(name, transactions: true)
 
-    {:ok, cache(transactional: trans2)} =
-      Cachex.Options.parse(name, transactional: false)
+    {:ok, cache(transactions: trans2)} =
+      Cachex.Options.parse(name, transactions: false)
 
-    {:ok, cache(transactional: trans3)} = Cachex.Options.parse(name, [])
+    {:ok, cache(transactions: trans3)} = Cachex.Options.parse(name, [])
 
     # the first one should be truthy, and the latter two falsey
     assert trans1

--- a/test/cachex/services/locksmith_test.exs
+++ b/test/cachex/services/locksmith_test.exs
@@ -31,8 +31,8 @@ defmodule Cachex.Services.LocksmithTest do
   # ensure that writes are queued unnecessarily.
   test "executing a write outside of a transaction" do
     # start two caches, one transactional, one not
-    cache1 = Helper.create_cache(transactional: true)
-    cache2 = Helper.create_cache(transactional: false)
+    cache1 = Helper.create_cache(transactions: true)
+    cache2 = Helper.create_cache(transactions: false)
 
     # fetch the states for the caches
     state1 = Services.Overseer.retrieve(cache1)
@@ -59,8 +59,8 @@ defmodule Cachex.Services.LocksmithTest do
   # itself, as it's needed to test the write execution.
   test "executing a transactional block" do
     # start two caches, one transactional, one not
-    cache1 = Helper.create_cache(transactional: false)
-    cache2 = Helper.create_cache(transactional: true)
+    cache1 = Helper.create_cache(transactions: false)
+    cache2 = Helper.create_cache(transactions: true)
 
     # fetch the states for the caches
     state1 = Services.Overseer.retrieve(cache1)
@@ -174,7 +174,7 @@ defmodule Cachex.Services.LocksmithTest do
     assert(Enum.sort(locked5) == ["key1", "key2", "key3"])
   end
 
-  # The Locksmith provides a `transactional/1` function to set the current
+  # The Locksmith provides a `start_transaction/1` function to set the current
   # process as transactional. This test just makes sure that this sets the flag
   # correctly between true/false.
   test "setting a transactional context" do


### PR DESCRIPTION
This fixes #335.

This renames the `:transactional` flag to be more consistent with other options, now named `:transactions`.