### PR TITLE
Abstract out provisioning across all component types

### DIFF
--- a/lib/cachex/hook.ex
+++ b/lib/cachex/hook.ex
@@ -58,7 +58,7 @@ defmodule Cachex.Hook do
 
   @doc false
   defmacro __using__(_) do
-    quote location: :keep do
+    quote location: :keep, generated: true do
       # force the Hook behaviours
       @behaviour Cachex.Hook
 

--- a/lib/cachex/policy/lrw/scheduled.ex
+++ b/lib/cachex/policy/lrw/scheduled.ex
@@ -58,7 +58,7 @@ defmodule Cachex.Policy.LRW.Scheduled do
   @doc false
   # Receives a provisioned cache instance.
   #
-  # The provided cache is then stored in the cache and used for cache calls going
+  # The provided cache is then stored in the state and used for cache calls going
   # forwards, in order to skip the lookups inside the cache overseer for performance.
   def handle_provision({:cache, cache}, {_cache, limit}),
     do: {:ok, {cache, limit}}

--- a/lib/cachex/provision.ex
+++ b/lib/cachex/provision.ex
@@ -39,7 +39,7 @@ defmodule Cachex.Provision do
 
   @doc false
   defmacro __using__(_) do
-    quote location: :keep do
+    quote location: :keep, generated: true do
       # use the provision behaviour
       @behaviour Cachex.Provision
 

--- a/lib/cachex/provision.ex
+++ b/lib/cachex/provision.ex
@@ -1,0 +1,79 @@
+defmodule Cachex.Provision do
+  @moduledoc """
+  Module controlling provisioning behaviour definitions.
+
+  This module defines the provisioning implementation for Cachex, allowing
+  components such as hooks and warmers to tap into state changes in the cache
+  table. By implementing `handle_provision/2` these components can be provided
+  with new versions of state as they're created.
+  """
+
+  #############
+  # Behaviour #
+  #############
+
+  @doc """
+  Returns an enumerable of provisions this implementation requires.
+
+  The current provisions available are:
+
+    * `cache` - a cache instance used to make cache calls with lower overhead.
+
+  This should always return an enumerable of atoms; in the case of no required
+  provisions an empty enumerable should be returned.
+  """
+  @callback provisions :: [atom]
+
+  @doc """
+  Handles a provisioning call.
+
+  The provided argument will be a Tuple dictating the type of value being
+  provisioned along with the value itself. This can be used to listen on
+  states required for hook executions (such as cache records).
+  """
+  @callback handle_provision({atom, any}, any) :: {:ok, any}
+
+  ##################
+  # Implementation #
+  ##################
+
+  @doc false
+  defmacro __using__(_) do
+    quote location: :keep do
+      # use the provision behaviour
+      @behaviour Cachex.Provision
+
+      #################
+      # Configuration #
+      #################
+
+      @doc false
+      def provisions,
+        do: []
+
+      # config overrides
+      defoverridable provisions: 0
+
+      #########################
+      # Notification Handlers #
+      #########################
+
+      @doc false
+      def handle_provision(provision, state),
+        do: {:ok, state}
+
+      # listener override
+      defoverridable handle_provision: 2
+
+      ##########################
+      # Private Implementation #
+      ##########################
+
+      @doc false
+      def handle_info({:cachex_provision, provision}, state) do
+        {:ok, new_state} = handle_provision(provision, state)
+        {:noreply, new_state}
+      end
+    end
+  end
+end

--- a/lib/cachex/services/incubator.ex
+++ b/lib/cachex/services/incubator.ex
@@ -37,6 +37,6 @@ defmodule Cachex.Services.Incubator do
   defp spec(warmer(module: module) = warmer, cache),
     do: %{
       id: module,
-      start: {GenServer, :start_link, [module, {cache, warmer}]}
+      start: {GenServer, :start_link, [module, {cache, warmer}, [name: module]]}
     }
 end

--- a/lib/cachex/services/overseer.ex
+++ b/lib/cachex/services/overseer.ex
@@ -20,6 +20,7 @@ defmodule Cachex.Services.Overseer do
 
   # add service aliases
   alias Services.Overseer
+  alias Services.Steward
 
   # constants for manager/table names
   @manager_name :cachex_overseer_manager
@@ -135,13 +136,7 @@ defmodule Cachex.Services.Overseer do
 
       register(name, nstate)
 
-      with hooks(pre: pre_hooks, post: post_hooks) <- cache(nstate, :hooks) do
-        pre_hooks
-        |> Enum.concat(post_hooks)
-        |> Enum.filter(&requires_state?/1)
-        |> Enum.map(&hook(&1, :name))
-        |> Enum.each(&send(&1, {:cachex_provision, {:cache, nstate}}))
-      end
+      Steward.provide(nstate, {:cache, nstate})
 
       nstate
     end)
@@ -180,12 +175,4 @@ defmodule Cachex.Services.Overseer do
       end
     end
   end
-
-  ###############
-  # Private API #
-  ###############
-
-  # Verifies if a hook has a cache provisioned.
-  defp requires_state?(hook(module: module)),
-    do: :cache in module.provisions()
 end

--- a/lib/cachex/services/steward.ex
+++ b/lib/cachex/services/steward.ex
@@ -1,0 +1,50 @@
+defmodule Cachex.Services.Steward do
+  @moduledoc """
+  Service module overseeing cache provisions.
+
+  This module controls state provision to Cachex components, such as hooks
+  and warmers. In previous versions of Cachex provisions were handled under
+  the `Cachex.Hook` behaviour, but the introduction of warmers meant that it
+  should be handled in a separate location.
+
+  This service module will handle the provision of state to relevant components
+  attached to a cache, without the caller having to think about it.
+  """
+  import Cachex.Spec
+
+  # recognised
+  @provisions [
+    :cache
+  ]
+
+  ##############
+  # Public API #
+  ##############
+
+  @doc """
+  Provides an state pair to relevant components.
+
+  This will send updated state to all interest components, but does not
+  wait for a response before returning. As provisions are handled in a
+  base implementation, we can be sure of safe implementation here.
+  """
+  @spec provide(Cachex.Spec.cache(), {atom, any}) :: :ok
+  def provide(cache() = cache, {key, _} = provision) when key in @provisions do
+    cache(hooks: hooks(pre: pre_hooks, post: post_hooks)) = cache
+    cache(warmers: warmers) = cache
+
+    hook_pairs =
+      pre_hooks
+      |> Enum.concat(post_hooks)
+      |> Enum.map(fn hook(module: mod, name: name) -> {name, mod} end)
+
+    warmer_pairs =
+      warmers
+      |> Enum.map(fn warmer(module: mod) -> {mod, mod} end)
+
+    warmer_pairs
+    |> Enum.concat(hook_pairs)
+    |> Enum.filter(fn {_, mod} -> key in mod.provisions() end)
+    |> Enum.each(fn {name, _} -> send(name, {:cachex_provision, provision}) end)
+  end
+end

--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -17,7 +17,7 @@ defmodule Cachex.Spec do
   #############
 
   # a list of accepted service suffixes for a cache instance
-  @services [:courier, :eternal, :janitor, :locksmith, :stats]
+  @services [:courier, :eternal, :janitor, :locksmith, :stats, :steward]
 
   #############
   # Typespecs #

--- a/lib/cachex/warmer.ex
+++ b/lib/cachex/warmer.ex
@@ -71,7 +71,6 @@ defmodule Cachex.Warmer do
       @doc """
       Return the provisions warmers require.
       """
-      @spec provisions :: [atom]
       def provisions,
         do: [:cache]
 

--- a/test/cachex/services/steward_test.exs
+++ b/test/cachex/services/steward_test.exs
@@ -1,0 +1,22 @@
+defmodule Cachex.Services.StewardTest do
+  use CachexCase
+
+  test "provisioning cache state" do
+    # bind our hook
+    ForwardHook.bind(
+      steward_forward_hook_provisions: [
+        provisions: [:cache]
+      ]
+    )
+
+    # create our hook with the provisions forwarded through to it
+    hook = ForwardHook.create(:steward_forward_hook_provisions)
+
+    # start a new cache using our forwarded hook
+    cache = Helper.create_cache(hooks: [hook])
+    cache = Services.Overseer.retrieve(cache)
+
+    # the provisioned value should match
+    assert_receive({:cache, ^cache})
+  end
+end

--- a/test/lib/cachex_case/forward_hook.ex
+++ b/test/lib/cachex_case/forward_hook.ex
@@ -60,24 +60,21 @@ defmodule CachexCase.ForwardHook do
           Forwards received messages to the state process.
           """
           def handle_notify(msg, results, proc) do
-            handle_info({msg, results}, proc)
-            {:ok, proc}
+            {:ok, handle_info({msg, results}, proc) && proc}
           end
 
           @doc """
           Forwards received messages to the state process.
           """
           def handle_provision(provision, proc) do
-            handle_info(provision, proc)
-            {:ok, proc}
+            {:ok, handle_info(provision, proc) && proc}
           end
 
           @doc """
           Forwards received messages to the state process.
           """
           def handle_info(msg, proc) do
-            send(proc, msg)
-            {:noreply, proc}
+            {:noreply, send(proc, msg) && proc}
           end
         end
       end


### PR DESCRIPTION
This fixes #332.

This PR will introduce a new behaviour and service based on provisioning. Instead of it being part of hooks, as before, it's now a separate `Cachex.Provision` module which can be used in any component to accept provisions. Most notable this is now also supported in warmers, so they can have an up to date version of the cache structure. 

This PR will also name the cache warmers after their module. This is temporary, because eventually they'll be named (via #334) - but naming was required to implement this properly. It was only not done in the past due to not being tied to a major release. 