### PR TITLE
Allow warmers to be have named processes

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -45,7 +45,6 @@ defmodule Cachex do
   alias Cachex.Services
 
   # alias any services
-  alias Services.Informant
   alias Services.Overseer
 
   # import util macros
@@ -308,7 +307,7 @@ defmodule Cachex do
          {:ok, true} <- ensure_unused(name),
          {:ok, cache} <- setup_env(name, options),
          {:ok, pid} = Supervisor.start_link(__MODULE__, cache, name: name),
-         {:ok, link} = Informant.link(cache),
+         {:ok, link} = Services.link(cache),
          ^link <- Overseer.update(name, link) do
       _ = run_warmers(cache)
       {:ok, pid}
@@ -1371,20 +1370,21 @@ defmodule Cachex do
 
   ## Options
 
-    * `:modules`
+    * `:only`
 
       An optional list of modules to warm, acting as a whitelist. The default
-      behaviour of this function is to trigger warming in all modules.
+      behaviour of this function is to trigger warming in all modules. You may
+      provide either the module name, or the registered warmer name.
 
   ## Examples
 
       iex> Cachex.warm(:my_cache)
       { :ok, [MyWarmer] }
 
-      iex> Cachex.warm(:my_cache, modules: [MyWarmer])
+      iex> Cachex.warm(:my_cache, only: [MyWarmer])
       { :ok, [MyWarmer] }
 
-      iex> Cachex.warm(:my_cache, modules: [])
+      iex> Cachex.warm(:my_cache, only: [])
       { :ok, [] }
 
   """

--- a/lib/cachex/actions/warm.ex
+++ b/lib/cachex/actions/warm.ex
@@ -18,18 +18,24 @@ defmodule Cachex.Actions.Warm do
   to our services module. This allows us to avoid having to track any special
   state in order to support manual warming.
 
-  You can provide a `:modules` option to restrict the warming to a specific
-  set of warmer modules. The list of modules which had a warming triggered will
-  be returned in the result of this call.
+  You can provide an `:only` option to restrict the warming to a specific set
+  of warmer modules or names. The list can contain either the name of the
+  module, or the name of the registered server. The list of warmer names which
+  had a warming triggered will be returned in the result of this call.
   """
   def execute(cache(warmers: warmers), options) do
-    mods = Keyword.get(options, :modules, nil)
+    only = Keyword.get(options, :only, nil)
 
-    handlers =
-      for warmer(module: mod) <- warmers, mods == nil or mod in mods do
-        send(mod, :cachex_warmer) && mod
+    match =
+      Enum.filter(warmers, fn warmer(module: mod, name: name) ->
+        only == nil or mod in only or name in only
+      end)
+
+    warmed =
+      for warmer(name: name) <- match do
+        send(name, :cachex_warmer) && name
       end
 
-    {:ok, handlers}
+    {:ok, warmed}
   end
 end

--- a/lib/cachex/services.ex
+++ b/lib/cachex/services.ex
@@ -88,10 +88,10 @@ defmodule Cachex.Services do
       cache(cache,
         hooks:
           hooks(
-            pre: attach_child_pid(pre, hook_processes),
-            post: attach_child_pid(post, hook_processes)
+            pre: attach_child(pre, hook_processes),
+            post: attach_child(post, hook_processes)
           ),
-        warmers: attach_child_pid(warmers, warmer_processes)
+        warmers: attach_child(warmers, warmer_processes)
       )
 
     {:ok, linked}
@@ -224,8 +224,8 @@ defmodule Cachex.Services do
   # Iterates a list of hooks and finds their reference in list of children.
   #
   # When there is a reference found, the hook is updated with the new PID.
-  defp attach_child_pid(struct, children) do
-    Enum.map(struct, fn
+  defp attach_child(structs, children) do
+    Enum.map(structs, fn
       warmer(module: module, name: nil) = warmer ->
         warmer(warmer, name: find_pid(children, module))
 

--- a/lib/cachex/services/incubator.ex
+++ b/lib/cachex/services/incubator.ex
@@ -33,10 +33,14 @@ defmodule Cachex.Services.Incubator do
   # Private API #
   ###############
 
-  # Generates a Supervisor specification for a hook.
-  defp spec(warmer(module: module) = warmer, cache),
-    do: %{
-      id: module,
-      start: {GenServer, :start_link, [module, {cache, warmer}, [name: module]]}
-    }
+  # Generates a Supervisor specification for a warmer.
+  defp spec(warmer(module: module, name: name) = warmer, cache) do
+    options =
+      case name do
+        nil -> [module, {cache, warmer}]
+        val -> [module, {cache, warmer}, [name: val]]
+      end
+
+    %{id: module, start: {GenServer, :start_link, options}}
+  end
 end

--- a/lib/cachex/services/steward.ex
+++ b/lib/cachex/services/steward.ex
@@ -53,6 +53,6 @@ defmodule Cachex.Services.Steward do
     do: {name, module}
 
   # Map a warmer into the name and module tuple
-  defp map_names(warmer(module: module)),
-    do: {module, module}
+  defp map_names(warmer(name: name, module: module)),
+    do: {name, module}
 end

--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -102,7 +102,8 @@ defmodule Cachex.Spec do
           record(:warmer,
             module: atom,
             state: any,
-            async: boolean
+            async: boolean,
+            name: GenServer.server()
           )
 
   ###########
@@ -259,7 +260,8 @@ defmodule Cachex.Spec do
   defrecord :warmer,
     module: nil,
     state: nil,
-    async: false
+    async: false,
+    name: nil
 
   ###############
   # Record Docs #

--- a/lib/cachex/spec/validator.ex
+++ b/lib/cachex/spec/validator.ex
@@ -135,11 +135,12 @@ defmodule Cachex.Spec.Validator do
   #
   # This will validate that the provided module correctly implements
   # the behaviour of `Cachex.Warmer` via function checking.
-  def valid?(:warmer, warmer(module: module)) do
+  def valid?(:warmer, warmer(module: module, name: name)) do
     check1 = behaviour?(module, Cachex.Warmer)
     check2 = check1 and {:interval, 0} in module.__info__(:functions)
     check3 = check2 and {:execute, 1} in module.__info__(:functions)
-    check3
+    check4 = check3 and nillable?(name, &(is_atom(&1) or is_pid(&1)))
+    check4
   end
 
   # Catch-all for invalid records.

--- a/test/cachex/actions/warm_test.exs
+++ b/test/cachex/actions/warm_test.exs
@@ -10,7 +10,15 @@ defmodule Cachex.Actions.WarmTest do
     end)
 
     # create a cache instance with a warmer
-    cache = Helper.create_cache(warmers: [warmer(module: :manual_warmer1)])
+    cache =
+      Helper.create_cache(
+        warmers: [
+          warmer(
+            module: :manual_warmer1,
+            name: :manual_warmer1
+          )
+        ]
+      )
 
     # check that the key was warmed
     assert Cachex.get!(cache, 1) == 1
@@ -39,7 +47,15 @@ defmodule Cachex.Actions.WarmTest do
     end)
 
     # create a cache instance with a warmer
-    cache = Helper.create_cache(warmers: [warmer(module: :manual_warmer2)])
+    cache =
+      Helper.create_cache(
+        warmers: [
+          warmer(
+            module: :manual_warmer2,
+            name: :manual_warmer2
+          )
+        ]
+      )
 
     # check that the key was warmed
     assert Cachex.get!(cache, 1) == 1
@@ -49,7 +65,7 @@ defmodule Cachex.Actions.WarmTest do
     assert Cachex.get!(cache, 1) == nil
 
     # manually trigger a cache warming
-    assert Cachex.warm(cache, modules: []) == {:ok, []}
+    assert Cachex.warm(cache, only: []) == {:ok, []}
 
     # wait for the warming
     :timer.sleep(50)
@@ -58,7 +74,7 @@ defmodule Cachex.Actions.WarmTest do
     assert Cachex.get!(cache, 1) == nil
 
     # manually trigger a cache warming, specifying our module
-    assert Cachex.warm(cache, modules: [:manual_warmer2]) ==
+    assert Cachex.warm(cache, only: [:manual_warmer2]) ==
              {:ok, [:manual_warmer2]}
 
     # wait for the warming

--- a/test/cachex/options_test.exs
+++ b/test/cachex/options_test.exs
@@ -406,7 +406,7 @@ defmodule Cachex.OptionsTest do
 
     results3 =
       Cachex.Options.parse(name,
-        warmers: [warmer(module: :options_test_warmer)]
+        warmers: [warmer(module: :options_test_warmer, name: :test)]
       )
 
     results4 = Cachex.Options.parse(name, warmers: ["warmer"])
@@ -419,7 +419,7 @@ defmodule Cachex.OptionsTest do
     # and then we check the warmers...
     assert warmers1 == []
     assert warmers2 == [warmer(module: :options_test_warmer)]
-    assert warmers3 == warmers2
+    assert warmers3 == [warmer(module: :options_test_warmer, name: :test)]
 
     # the last one should be invalid
     assert results4 == {:error, :invalid_warmer}


### PR DESCRIPTION
This fixes #334.

This MR updates the `warmer` struct to support a `name` value, which can either be left `nil` and populated with the warmer `pid`, or an `atom`. As the incubator and informant services now look similar, I pulled the common logic for linking into the parent `Cachex.Services`. Due to warmers being either named or not, you can now use `only` to filter by module/name when warming the cache. 