### PR TITLE
Raise minimum version to Elixir v1.7

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,7 +1,9 @@
-# This file contains the configuration for Credo.
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
 #
 # If you find anything wrong or unclear in this file, please report an
 # issue on GitHub: https://github.com/rrrene/credo/issues
+#
 %{
   #
   # You can have as many configs as you like in the `configs:` field.
@@ -10,89 +12,196 @@
       #
       # Run any config using `mix credo -C <name>`. If no config name is given
       # "default" is used.
+      #
       name: "default",
       #
-      # these are the files included in the analysis
+      # These are the files included in the analysis:
       files: %{
         #
-        # you can give explicit globs or simply directories
-        # in the latter case `**/*.{ex,exs}` will be used
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+        #
         included: ["lib/", "src/", "web/", "apps/"],
         excluded: []
       },
       #
-      # The `checks:` field contains all the checks that are run. You can
-      # customize the parameters of any given check by adding a second element
+      # Load and configure plugins here:
+      #
+      plugins: [],
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      #
+      requires: [],
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      #
+      strict: false,
+      #
+      # To modify the timeout for parsing files, change this value:
+      #
+      parse_timeout: 5000,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      #
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
       # to the tuple.
       #
-      # There are two ways of deactivating a check:
-      # 1. deleting the check from this list
-      # 2. putting `false` as second element (to quickly "comment it out"):
+      # To disable a check put `false` as second element:
       #
-      #      {Credo.Check.Consistency.ExceptionNames, false}
+      #     {Credo.Check.Design.DuplicatedCode, false}
       #
-      checks: [
-        {Credo.Check.Consistency.ExceptionNames},
-        {Credo.Check.Consistency.LineEndings, false},
-        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
-        {Credo.Check.Consistency.ParameterPatternMatching},
-        {Credo.Check.Consistency.SpaceAroundOperators},
-        {Credo.Check.Consistency.SpaceInParentheses, false},
-        {Credo.Check.Consistency.TabsOrSpaces},
+      checks: %{
+        enabled: [
+          #
+          ## Consistency Checks
+          #
+          {Credo.Check.Consistency.ExceptionNames, []},
+          {Credo.Check.Consistency.LineEndings, []},
+          {Credo.Check.Consistency.ParameterPatternMatching, []},
+          {Credo.Check.Consistency.SpaceAroundOperators, []},
+          {Credo.Check.Consistency.SpaceInParentheses, []},
+          {Credo.Check.Consistency.TabsOrSpaces, []},
 
-        # For some checks, like AliasUsage, you can only customize the priority
-        # Priority values are: `low, normal, high, higher`
-        {Credo.Check.Design.AliasUsage, priority: :low},
-        # For others you can set parameters
-        {Credo.Check.Design.DuplicatedCode,
-         mass_threshold: 16, nodes_threshold: 2},
-        {Credo.Check.Design.TagTODO, false},
-        {Credo.Check.Design.TagFIXME, false},
-        {Credo.Check.Readability.FunctionNames},
-        {Credo.Check.Readability.LargeNumbers},
-        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 80},
-        {Credo.Check.Readability.ModuleAttributeNames},
-        {Credo.Check.Readability.ModuleDoc},
-        {Credo.Check.Readability.ModuleNames},
-        {Credo.Check.Readability.ParenthesesInCondition},
-        {Credo.Check.Readability.PredicateFunctionNames, false},
-        {Credo.Check.Readability.PreferImplicitTry},
-        {Credo.Check.Readability.RedundantBlankLines},
-        {Credo.Check.Readability.Specs, false},
-        {Credo.Check.Readability.StringSigils},
-        {Credo.Check.Readability.TrailingBlankLine},
-        {Credo.Check.Readability.TrailingWhiteSpace},
-        {Credo.Check.Readability.VariableNames},
-        {Credo.Check.Refactor.DoubleBooleanNegation},
-        {Credo.Check.Refactor.ABCSize, max_size: 50},
-        {Credo.Check.Refactor.CaseTrivialMatches, false},
-        {Credo.Check.Refactor.CondStatements},
-        {Credo.Check.Refactor.FunctionArity},
-        {Credo.Check.Refactor.MatchInCondition},
-        {Credo.Check.Refactor.NegatedConditionsInUnless},
-        {Credo.Check.Refactor.NegatedConditionsWithElse},
-        {Credo.Check.Refactor.Nesting},
-        {Credo.Check.Refactor.PipeChainStart},
-        {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 10},
-        {Credo.Check.Refactor.NegatedConditionsInUnless},
-        {Credo.Check.Refactor.NegatedConditionsWithElse},
-        {Credo.Check.Refactor.Nesting},
-        {Credo.Check.Refactor.UnlessWithElse},
-        {Credo.Check.Refactor.VariableRebinding},
-        {Credo.Check.Warning.BoolOperationOnSameValues},
-        {Credo.Check.Warning.IExPry},
-        {Credo.Check.Warning.IoInspect},
-        {Credo.Check.Warning.OperationOnSameValues},
-        {Credo.Check.Warning.OperationWithConstantResult},
-        {Credo.Check.Warning.UnusedEnumOperation},
-        {Credo.Check.Warning.UnusedFileOperation},
-        {Credo.Check.Warning.UnusedKeywordOperation},
-        {Credo.Check.Warning.UnusedListOperation},
-        {Credo.Check.Warning.UnusedPathOperation},
-        {Credo.Check.Warning.UnusedRegexOperation},
-        {Credo.Check.Warning.UnusedStringOperation},
-        {Credo.Check.Warning.UnusedTupleOperation}
-      ]
+          #
+          ## Design Checks
+          #
+          # You can customize the priority of any check
+          # Priority values are: `low, normal, high, higher`
+          #
+          {Credo.Check.Design.AliasUsage,
+           [
+             priority: :low,
+             if_nested_deeper_than: 2,
+             if_called_more_often_than: 0
+           ]},
+
+          #
+          ## Readability Checks
+          #
+          {Credo.Check.Readability.AliasOrder, []},
+          {Credo.Check.Readability.FunctionNames, []},
+          {Credo.Check.Readability.LargeNumbers, []},
+          {Credo.Check.Readability.MaxLineLength,
+           [priority: :low, max_length: 120]},
+          {Credo.Check.Readability.ModuleAttributeNames, []},
+          {Credo.Check.Readability.ModuleDoc, []},
+          {Credo.Check.Readability.ModuleNames, []},
+          {Credo.Check.Readability.ParenthesesInCondition, []},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+          {Credo.Check.Readability.PipeIntoAnonymousFunctions, []},
+          {Credo.Check.Readability.PredicateFunctionNames, []},
+          {Credo.Check.Readability.PreferImplicitTry, []},
+          {Credo.Check.Readability.RedundantBlankLines, []},
+          {Credo.Check.Readability.Semicolons, []},
+          {Credo.Check.Readability.SpaceAfterCommas, []},
+          {Credo.Check.Readability.StringSigils, []},
+          {Credo.Check.Readability.TrailingBlankLine, []},
+          {Credo.Check.Readability.TrailingWhiteSpace, []},
+          {Credo.Check.Readability.UnnecessaryAliasExpansion, []},
+          {Credo.Check.Readability.VariableNames, []},
+          {Credo.Check.Readability.WithSingleClause, []},
+
+          #
+          ## Refactoring Opportunities
+          #
+          {Credo.Check.Refactor.Apply, []},
+          {Credo.Check.Refactor.CondStatements, []},
+          {Credo.Check.Refactor.CyclomaticComplexity, [max_complexity: 10]},
+          {Credo.Check.Refactor.FilterCount, []},
+          {Credo.Check.Refactor.FilterFilter, []},
+          {Credo.Check.Refactor.FunctionArity, []},
+          {Credo.Check.Refactor.LongQuoteBlocks, []},
+          {Credo.Check.Refactor.MapJoin, []},
+          {Credo.Check.Refactor.MatchInCondition, []},
+          {Credo.Check.Refactor.NegatedConditionsInUnless, []},
+          {Credo.Check.Refactor.NegatedConditionsWithElse, []},
+          {Credo.Check.Refactor.Nesting, [max_nesting: 3]},
+          {Credo.Check.Refactor.RedundantWithClauseResult, []},
+          {Credo.Check.Refactor.RejectReject, []},
+          {Credo.Check.Refactor.UnlessWithElse, []},
+          {Credo.Check.Refactor.WithClauses, []},
+
+          #
+          ## Warnings
+          #
+          {Credo.Check.Warning.ApplicationConfigInModuleAttribute, []},
+          {Credo.Check.Warning.BoolOperationOnSameValues, []},
+          {Credo.Check.Warning.Dbg, []},
+          {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
+          {Credo.Check.Warning.IExPry, []},
+          {Credo.Check.Warning.IoInspect, []},
+          {Credo.Check.Warning.MissedMetadataKeyInLoggerConfig, []},
+          {Credo.Check.Warning.OperationOnSameValues, []},
+          {Credo.Check.Warning.OperationWithConstantResult, []},
+          {Credo.Check.Warning.RaiseInsideRescue, []},
+          {Credo.Check.Warning.SpecWithStruct, []},
+          {Credo.Check.Warning.UnsafeExec, []},
+          {Credo.Check.Warning.UnusedEnumOperation, []},
+          {Credo.Check.Warning.UnusedFileOperation, []},
+          {Credo.Check.Warning.UnusedKeywordOperation, []},
+          {Credo.Check.Warning.UnusedListOperation, []},
+          {Credo.Check.Warning.UnusedPathOperation, []},
+          {Credo.Check.Warning.UnusedRegexOperation, []},
+          {Credo.Check.Warning.UnusedStringOperation, []},
+          {Credo.Check.Warning.UnusedTupleOperation, []},
+          {Credo.Check.Warning.WrongTestFileExtension, []}
+        ],
+        disabled: [
+          #
+          # Checks scheduled for next check update (opt-in for now)
+          {Credo.Check.Refactor.UtcNowTruncate, []},
+
+          #
+          # Controversial and experimental checks (opt-in, just move the check to `:enabled`
+          #   and be sure to use `mix credo --strict` to see low priority checks)
+          #
+          {Credo.Check.Consistency.MultiAliasImportRequireUse, []},
+          {Credo.Check.Consistency.UnusedVariableNames, []},
+          {Credo.Check.Design.DuplicatedCode, []},
+          {Credo.Check.Design.SkipTestWithoutComment, []},
+          {Credo.Check.Readability.AliasAs, []},
+          {Credo.Check.Readability.BlockPipe, []},
+          {Credo.Check.Readability.ImplTrue, []},
+          {Credo.Check.Readability.MultiAlias, []},
+          {Credo.Check.Readability.NestedFunctionCalls, []},
+          {Credo.Check.Readability.OneArityFunctionInPipe, []},
+          {Credo.Check.Readability.OnePipePerLine, []},
+          {Credo.Check.Readability.SeparateAliasRequire, []},
+          {Credo.Check.Readability.SingleFunctionToBlockPipe, []},
+          {Credo.Check.Readability.SinglePipe, []},
+          {Credo.Check.Readability.Specs, []},
+          {Credo.Check.Readability.StrictModuleLayout, []},
+          {Credo.Check.Readability.WithCustomTaggedTuple, []},
+          {Credo.Check.Refactor.ABCSize, []},
+          {Credo.Check.Refactor.AppendSingleItem, []},
+          {Credo.Check.Refactor.DoubleBooleanNegation, []},
+          {Credo.Check.Refactor.FilterReject, []},
+          {Credo.Check.Refactor.IoPuts, []},
+          {Credo.Check.Refactor.MapMap, []},
+          {Credo.Check.Refactor.ModuleDependencies, []},
+          {Credo.Check.Refactor.NegatedIsNil, []},
+          {Credo.Check.Refactor.PassAsyncInTestCases, []},
+          {Credo.Check.Refactor.PipeChainStart, []},
+          {Credo.Check.Refactor.RejectFilter, []},
+          {Credo.Check.Refactor.VariableRebinding, []},
+          {Credo.Check.Warning.LazyLogging, []},
+          {Credo.Check.Warning.LeakyEnvironment, []},
+          {Credo.Check.Warning.MapGetUnsafePass, []},
+          {Credo.Check.Warning.MixEnv, []},
+          {Credo.Check.Warning.UnsafeToAtom, []}
+
+          # {Credo.Check.Refactor.MapInto, []},
+
+          #
+          # Custom checks can be created using `mix credo.gen.check`.
+          #
+        ]
+      }
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,9 @@ jobs:
         - '1.9'
         - '1.8'
         - '1.7'
-        - '1.6'
-        - '1.5'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Environment
         run: |
@@ -50,7 +48,7 @@ jobs:
     env:
       MIX_ENV: cover
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Environment
         run: |
@@ -70,7 +68,7 @@ jobs:
     container:
       image: elixir:1.16
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Environment
         run: |

--- a/lib/cachex/services/courier.ex
+++ b/lib/cachex/services/courier.ex
@@ -87,7 +87,7 @@ defmodule Cachex.Services.Courier do
                         :error,
                         %ExecutionError{
                           message: Exception.message(e),
-                          stack: stack_compat() ++ stack
+                          stack: __STACKTRACE__ ++ stack
                         }
                       }
                   end

--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -500,18 +500,6 @@ defmodule Cachex.Spec do
     do: quote(do: [{:via, unquote(action)} | unquote(options)])
 
   @doc """
-  Retrieves the currently handled stacktrace.
-  """
-  @spec stack_compat :: any
-  defmacro stack_compat() do
-    if Version.match?(System.version(), ">= 1.7.0") do
-      quote(do: __STACKTRACE__)
-    else
-      quote(do: System.stacktrace())
-    end
-  end
-
-  @doc """
   Wraps a value inside a tagged Tuple using the provided tag.
   """
   @spec wrap(any, atom) :: {atom, any}

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Cachex.Mixfile do
         maintainers: ["Isaac Whitfield"]
       },
       version: @version,
-      elixir: "~> 1.5",
+      elixir: "~> 1.7",
       deps: deps(),
       docs: [
         source_ref: "v#{@version}",
@@ -101,7 +101,7 @@ defmodule Cachex.Mixfile do
       {:excoveralls, "~> 0.15", optional: true, only: [:cover]},
       {:local_cluster, "~> 1.1", optional: true, only: [:cover, :test]},
       # Linting dependencies
-      {:credo, "~> 1.6", optional: true, only: [:lint]},
+      {:credo, "~> 1.7", optional: true, only: [:lint]},
       # Benchmarking dependencies
       {:benchee, "~> 1.1", optional: true, only: [:bench]},
       {:benchee_html, "~> 1.0", optional: true, only: [:bench]},


### PR DESCRIPTION
Fixes #349.

I don't expect many people will be bothered about this, plus it still dates back 6 years. In future I might be more aggressive about adopting newer versions, but for now I'm sticking in line with other tooling. 

If you need Elixir 1.5 or Elixir 1.6 compatibility, please use the latest version of `cachex @ v3`. 