### PR TITLE
Refactor cluster based dispatch and enable customizable routers

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -3,7 +3,6 @@
     "treat_no_relevant_lines_as_covered": true
   },
   "skip_files": [
-    "lib/cachex/router.ex",
     "lib/cachex/spec.ex",
     "mix.exs"
   ]

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -1479,7 +1479,7 @@ defmodule Cachex do
   defp setup_router(cache(nodes: nodes, router: router) = cache) do
     router(module: module, options: options) = router
 
-    state = module.init(nodes, options)
+    state = module.new(nodes, options)
     local = module.nodes(state) == [node()]
 
     {:ok, cache(cache, router: router(router, state: state, enabled: !local))}

--- a/lib/cachex/actions/transaction.ex
+++ b/lib/cachex/actions/transaction.ex
@@ -24,7 +24,10 @@ defmodule Cachex.Actions.Transaction do
   """
   def execute(cache() = cache, keys, operation, _options) do
     Locksmith.transaction(cache, keys, fn ->
-      {:ok, operation.(cache)}
+      case :erlang.fun_info(operation)[:arity] do
+        0 -> {:ok, operation.()}
+        1 -> {:ok, operation.(cache)}
+      end
     end)
   end
 end

--- a/lib/cachex/errors.ex
+++ b/lib/cachex/errors.ex
@@ -23,6 +23,7 @@ defmodule Cachex.Errors do
     :invalid_nodes,
     :invalid_option,
     :invalid_pairs,
+    :invalid_router,
     :invalid_warmer,
     :janitor_disabled,
     :no_cache,
@@ -98,6 +99,9 @@ defmodule Cachex.Errors do
 
   def long_form(:invalid_pairs),
     do: "Invalid insertion pairs provided"
+
+  def long_form(:invalid_router),
+    do: "Invalid router definition provided"
 
   def long_form(:invalid_warmer),
     do: "Invalid warmer definition provided"

--- a/lib/cachex/errors.ex
+++ b/lib/cachex/errors.ex
@@ -20,7 +20,6 @@ defmodule Cachex.Errors do
     :invalid_limit,
     :invalid_match,
     :invalid_name,
-    :invalid_nodes,
     :invalid_option,
     :invalid_pairs,
     :invalid_router,
@@ -90,9 +89,6 @@ defmodule Cachex.Errors do
 
   def long_form(:invalid_name),
     do: "Invalid cache name provided"
-
-  def long_form(:invalid_nodes),
-    do: "Invalid nodes list provided"
 
   def long_form(:invalid_option),
     do: "Invalid option syntax provided"

--- a/lib/cachex/options.ex
+++ b/lib/cachex/options.ex
@@ -308,7 +308,20 @@ defmodule Cachex.Options do
         error(:invalid_nodes)
 
       true ->
-        cache(cache, nodes: nodes)
+        cache(cache,
+          nodes: nodes,
+          cluster:
+            cluster(
+              enabled: nodes != [node()],
+              router: fn key, nodes ->
+                key
+                |> :erlang.phash2()
+                |> Jumper.slot(length(nodes))
+              end,
+              nodes: nodes
+            )
+        )
+
         # coveralls-ignore-stop
     end
   end

--- a/lib/cachex/options.ex
+++ b/lib/cachex/options.ex
@@ -73,8 +73,9 @@ defmodule Cachex.Options do
       end)
 
     # wrap for compatibility
-    with cache() <- parsed,
-         do: {:ok, parsed}
+    with cache() <- parsed do
+      {:ok, parsed}
+    end
   end
 
   @doc """
@@ -309,16 +310,18 @@ defmodule Cachex.Options do
 
       true ->
         cache(cache,
-          nodes: nodes,
           cluster:
             cluster(
               enabled: nodes != [node()],
               router: fn key, nodes ->
-                key
-                |> :erlang.phash2()
-                |> Jumper.slot(length(nodes))
+                slot =
+                  key
+                  |> :erlang.phash2()
+                  |> Jumper.slot(length(nodes))
+
+                Enum.at(nodes, slot)
               end,
-              nodes: nodes
+              state: nodes
             )
         )
 

--- a/lib/cachex/options.ex
+++ b/lib/cachex/options.ex
@@ -17,7 +17,6 @@ defmodule Cachex.Options do
   # option parser order
   @option_parsers [
     :name,
-    :nodes,
     :limit,
     :hooks,
     :router,
@@ -285,35 +284,6 @@ defmodule Cachex.Options do
   # rather than having to special cache the parsing of the name.
   defp parse_type(:name, name, _options),
     do: cache(name: name)
-
-  # Configures any nodes assigned to the cache.
-  #
-  # This will enforce a non-empty list of nodes, containing at least
-  # the current local node. The list will be deduplicated, and sorted
-  # to ensure a deterministic ordering across nodes.
-  defp parse_type(:nodes, cache, options) do
-    nodes =
-      options
-      |> Keyword.get(:nodes, [])
-      |> Enum.concat([node()])
-      |> Enum.uniq()
-      |> Enum.sort()
-
-    valid =
-      nodes
-      |> List.delete(node())
-      |> Enum.all?(&Node.connect/1)
-
-    case valid do
-      # coveralls-ignore-start
-      false ->
-        error(:invalid_nodes)
-
-      true ->
-        cache(cache, nodes: nodes)
-        # coveralls-ignore-stop
-    end
-  end
 
   # Configures a cache based on ordering flags.
   #

--- a/lib/cachex/policy/lrw/evented.ex
+++ b/lib/cachex/policy/lrw/evented.ex
@@ -16,8 +16,8 @@ defmodule Cachex.Policy.LRW.Evented do
   # add internal aliases
   alias Cachex.Policy.LRW
 
-  # actions which didn't trigger a write
-  @ignored [:error, :ignored]
+  # actions which didn't trigger
+  @ignored [:error, :ignore]
 
   ######################
   # Hook Configuration #

--- a/lib/cachex/router.ex
+++ b/lib/cachex/router.ex
@@ -13,12 +13,12 @@ defmodule Cachex.Router do
   #############
 
   @doc """
-  Initializes a routing state using a list of nodes.
+  Initialize a routing state using a list of nodes.
   """
   @callback init(nodes :: [atom], options :: Keyword.t()) :: any
 
   @doc """
-  Retrieves the list of nodes from a routing state.
+  Retrieve the list of nodes from a routing state.
   """
   @callback nodes(state :: any) :: [atom]
 

--- a/lib/cachex/router.ex
+++ b/lib/cachex/router.ex
@@ -15,7 +15,7 @@ defmodule Cachex.Router do
   @doc """
   Initialize a routing state using a list of nodes.
   """
-  @callback init(nodes :: [atom], options :: Keyword.t()) :: any
+  @callback new(nodes :: [atom], options :: Keyword.t()) :: any
 
   @doc """
   Retrieve the list of nodes from a routing state.

--- a/lib/cachex/router.ex
+++ b/lib/cachex/router.ex
@@ -1,308 +1,64 @@
 defmodule Cachex.Router do
   @moduledoc """
-  Routing module to dispatch Cachex actions to their execution environment.
+  Module controlling routing behaviour definitions.
 
-  This module acts as the single source of dispatch within Cachex. In prior
-  versions the backing actions were called directly from the main interface
-  and were wrapped in macros, which was difficult to maintain and also quite
-  noisy. Now that all execution flows via the router, this is no longer an
-  issue and it also serves as a gateway to distribution in the future.
+  This module defines the router implementations for Cachex, allowing the user
+  to route commands between nodes in a cache cluster. This means that users
+  can provide their own routing and rebalancing logic without having to depend
+  on it being included in Cachex.
   """
-  alias Cachex.Router
-  alias Cachex.Services
 
-  # add some service aliases
-  alias Services.Informant
-  alias Services.Overseer
-
-  # import macro stuff
-  import Cachex.Errors
-  import Cachex.Spec
-
-  ##############
-  # Public API #
-  ##############
+  #############
+  # Behaviour #
+  #############
 
   @doc """
-  Dispatches a call to an appropriate execution environment.
-
-  This acts as a macro just to avoid the overhead of slicing up module
-  names at runtime, when they can be guaranteed at compile time much
-  more easily.
+  Initializes a routing state using a list of nodes.
   """
-  defmacro call(cache, {action, _arguments} = call) do
-    act_name =
-      action
-      |> Kernel.to_string()
-      |> String.replace_trailing("?", "")
-      |> Macro.camelize()
-
-    act_join = :"Elixir.Cachex.Actions.#{act_name}"
-
-    quote do
-      Overseer.enforce unquote(cache) do
-        call = unquote(call)
-        cache = var!(cache)
-        module = unquote(act_join)
-
-        Router.execute(cache, module, call)
-      end
-    end
-  end
+  @callback init(nodes :: [atom], options :: Keyword.t()) :: any
 
   @doc """
-  Executes a previously dispatched action.
-
-  This macro should not be called externally; the only reason it remains
-  public is due to the code injected by the `dispatch/2` macro.
+  Retrieves the list of nodes from a routing state.
   """
-  @spec execute(Cachex.Spec.cache(), atom, {atom, [any]}) :: any
-  def execute(cache(cluster: cluster(enabled: false)) = cache, module, call),
-    do: route_local(cache, module, call)
+  @callback nodes(state :: any) :: [atom]
 
-  def execute(cache(cluster: cluster(enabled: true)) = cache, module, call),
-    do: route_cluster(cache, module, call)
+  @doc """
+  Route a provided key to a node in a routing state.
+  """
+  @callback route(state :: any, key :: any) :: atom
 
-  ###############
-  # Private API #
-  ###############
+  @doc """
+  Attach a new node to a routing state.
+  """
+  @callback attach(state :: any, node :: atom) :: any
 
-  # Results merging for distributed cache results.
-  #
-  # Follows these rules:
-  #
-  # - Lists are always concatenated.
-  # - Numbers are always summed.
-  # - Booleans are always AND-ed.
-  # - Maps are always merged (recursively).
-  #
-  # This has to be public due to scopes, but we hide the docs
-  # because we don't really care for anybody else calling it.
-  defp result_merge(left, right) when is_list(left),
-    do: left ++ right
+  @doc """
+  Detach an existing node from a routing state.
+  """
+  @callback detach(state :: any, node :: atom) :: any
 
-  defp result_merge(left, right) when is_number(left),
-    do: left + right
+  @doc false
+  defmacro __using__(_) do
+    quote location: :keep, generated: true do
+      # inherit the behaviour
+      @behaviour Cachex.Router
 
-  defp result_merge(left, right) when is_boolean(left),
-    do: left && right
-
-  defp result_merge(left, right) when is_map(left) do
-    Map.merge(left, right, fn
-      :creation_date, _left, right ->
-        right
-
-      key, left, right when key in [:hit_rate, :miss_rate] ->
-        (left + right) / 2
-
-      _key, left, right ->
-        result_merge(left, right)
-    end)
-  end
-
-  # Provides handling for local actions on this node.
-  #
-  # This will provide handling of notifications across hooks before and after
-  # the execution of an action. This is taken from code formerly in the old
-  # `Cachex.Actions` module, but has been moved here as it's more appropriate.
-  #
-  # If `notify` is set to false, notifications are disabled and the call is
-  # simply executed as is. If `via` is provided, you can override the handle
-  # passed to the hooks (useful for re-use of functions). An example of this
-  # is `decr/4` which simply calls `incr/4` with `via: { :decr, arguments }`.
-  defp route_local(cache, module, {_action, arguments} = call) do
-    option = List.last(arguments)
-    notify = Keyword.get(option, :notify, true)
-
-    message =
-      notify &&
-        case option[:via] do
-          msg when not is_tuple(msg) -> call
-          msg -> msg
-        end
-
-    notify && Informant.broadcast(cache, message)
-    result = apply(module, :execute, [cache | arguments])
-
-    if notify do
-      Informant.broadcast(
-        cache,
-        message,
-        Keyword.get(option, :hook_result, result)
-      )
-    end
-
-    result
-  end
-
-  # actions based on a key
-  @keyed_actions [
-    :del,
-    :exists?,
-    :expire,
-    :fetch,
-    :get,
-    :get_and_update,
-    :incr,
-    :invoke,
-    :put,
-    :refresh,
-    :take,
-    :touch,
-    :ttl,
-    :update
-  ]
-
-  # Provides handling to key-based actions distributed to remote nodes.
-  #
-  # The algorithm here is simple; hash the key and slot the value using JCH into
-  # the total number of slots available (i.e. the count of the nodes). If it comes
-  # out to the local node, just execute the local code, otherwise RPC the base call
-  # to the remote node, and just assume that it'll correctly handle it.
-  defp route_cluster(cache, module, {action, [key | _]} = call)
-       when action in @keyed_actions do
-    cache(cluster: cluster(router: router, state: nodes)) = cache
-    route_node(cache, module, call, router.(key, nodes))
-  end
-
-  # actions which merge outputs
-  @merge_actions [
-    :clear,
-    :count,
-    :empty?,
-    :export,
-    :import,
-    :keys,
-    :purge,
-    :reset,
-    :size,
-    :stats
-  ]
-
-  # Provides handling of cross-node actions distributed over remote nodes.
-  #
-  # This will do an RPC call across all nodes to fetch their results and merge
-  # them with the results on the local node. The hooks will only be notified
-  # on the local node, due to an annoying recursion issue when handling the
-  # same across all nodes - seems to provide better logic though.
-  defp route_cluster(cache, module, {action, arguments} = call)
-       when action in @merge_actions do
-    # fetch the nodes from the cluster state
-    cache(cluster: cluster(state: nodes)) = cache
-
-    # all calls have options we can use
-    options = List.last(arguments)
-
-    # can force local node setting local: true
-    results =
-      case Keyword.get(options, :local) do
-        true ->
-          []
-
-        _any ->
-          # don't want to execute on the local node
-          other_nodes = List.delete(nodes, node())
-
-          # execute the call on all other nodes
-          {results, _} =
-            :rpc.multicall(
-              other_nodes,
-              module,
-              :execute,
-              [cache | arguments]
-            )
-
-          results
-      end
-
-    # execution on the local node, using the local macros and then unpack
-    {:ok, result} = route_local(cache, module, call)
-
-    # results merge
-    merge_result =
-      results
-      |> Enum.map(&elem(&1, 1))
-      |> Enum.reduce(result, &result_merge/2)
-
-    # return after merge
-    {:ok, merge_result}
-  end
-
-  # actions which always run locally
-  @local_actions [:dump, :inspect, :load, :warm]
-
-  # Provides handling of `:inspect` operations.
-  #
-  # These operations are guaranteed to run on the local nodes.
-  defp route_cluster(cache, module, {action, _arguments} = call)
-       when action in @local_actions,
-       do: route_local(cache, module, call)
-
-  # Provides handling of `:put_many` operations.
-  #
-  # These operations can only execute if their keys slot to the same remote nodes.
-  defp route_cluster(cache, module, {:put_many, _arguments} = call),
-    do: route_batch(cache, module, call, &elem(&1, 0))
-
-  # Provides handling of `:transaction` operations.
-  #
-  # These operations can only execute if their keys slot to the same remote nodes.
-  defp route_cluster(cache, module, {:transaction, [keys | _]} = call) do
-    case keys do
-      [] -> route_local(cache, module, call)
-      _ -> route_batch(cache, module, call, & &1)
-    end
-  end
-
-  # Any other actions are explicitly disabled in distributed environments.
-  defp route_cluster(_cache, _module, _call),
-    do: error(:non_distributed)
-
-  # Calls a slot for the provided cache action if all keys slot to the same node.
-  #
-  # This is a delegate handler for `route_node/4`, but ensures that all keys slot to the
-  # same node to avoid the case where we have to fork a call out internally.
-  defp route_batch(cache, module, {_action, [keys | _]} = call, mapper) do
-    # map all keys to a slot in the nodes list
-    cache(cluster: cluster(router: router, state: nodes)) = cache
-    slots = Enum.map(keys, &router.(mapper.(&1), nodes))
-
-    # unique to avoid dups
-    case Enum.uniq(slots) do
-      # if there's a single slot it's safe to continue with the call to the remote
-      [slot] ->
-        route_node(cache, module, call, slot)
-
-      # otherwise, cross_slot errors!
-      _disable ->
-        error(:cross_slot)
-    end
-  end
-
-  # Calls a node for the provided cache action.
-  #
-  # This will determine a local slot and delegate locally if so, bypassing
-  # any RPC calls in order to gain a slight bit of performance.
-  defp route_node(cache, module, {action, arguments} = call, node) do
-    current = node()
-    cache(name: name) = cache
-
-    case node do
-      ^current ->
-        route_local(cache, module, call)
-
-      targeted ->
-        result =
-          :rpc.call(
-            targeted,
-            Cachex,
-            action,
-            [name | arguments]
+      @doc false
+      def attach(state, node),
+        do:
+          raise(RuntimeError,
+            message: "Router does not support node addition"
           )
 
-        with {:badrpc, reason} <- result do
-          {:error, reason}
-        end
+      @doc false
+      def detach(state, node),
+        do:
+          raise(RuntimeError,
+            message: "Router does not support node removal"
+          )
+
+      # state modifiers are overridable
+      defoverridable attach: 2, detach: 2
     end
   end
 end

--- a/lib/cachex/router/jump.ex
+++ b/lib/cachex/router/jump.ex
@@ -1,0 +1,44 @@
+defmodule Cachex.Router.Jump do
+  @moduledoc """
+  Basic routing implementation based on Jump Consistent Hash.
+
+  This implementation backed Cachex's distribution in the v3.x lineage,
+  and is suitable for clusters of a static size. Attaching and detaching
+  nodes after initialization is not supported and will cause an error
+  if you attempt to do so.
+
+  For more information on the algorithm backing this router, please
+  see the appropriate [publication](https://arxiv.org/pdf/1406.2294).
+  """
+  use Cachex.Router
+
+  @doc """
+  Initializes a routing state using a list of nodes.
+
+  In the case of this router the routing state is simply the list
+  of nodes being tracked, with duplicate entries removed.
+  """
+  @spec init(nodes :: [atom], options :: Keyword.t()) :: [atom]
+  def init(nodes, _options),
+    do: Enum.uniq(nodes)
+
+  @doc """
+  Retrieves the list of nodes from a routing state.
+  """
+  @spec nodes(nodes :: [atom]) :: [atom]
+  def nodes(nodes),
+    do: nodes
+
+  @doc """
+  Route a provided key to a node in a routing state.
+  """
+  @spec route(nodes :: [atom], key :: any) :: atom
+  def route(nodes, key) do
+    slot =
+      key
+      |> :erlang.phash2()
+      |> Jumper.slot(length(nodes))
+
+    Enum.at(nodes, slot)
+  end
+end

--- a/lib/cachex/router/jump.ex
+++ b/lib/cachex/router/jump.ex
@@ -13,7 +13,7 @@ defmodule Cachex.Router.Jump do
   use Cachex.Router
 
   @doc """
-  Initializes a routing state using a list of nodes.
+  Initialize a routing state using a list of nodes.
 
   In the case of this router the routing state is simply the list
   of nodes being tracked, with duplicate entries removed.
@@ -23,7 +23,7 @@ defmodule Cachex.Router.Jump do
     do: Enum.uniq(nodes)
 
   @doc """
-  Retrieves the list of nodes from a routing state.
+  Retrieve the list of nodes from a routing state.
   """
   @spec nodes(nodes :: [atom]) :: [atom]
   def nodes(nodes),

--- a/lib/cachex/router/jump.ex
+++ b/lib/cachex/router/jump.ex
@@ -18,9 +18,12 @@ defmodule Cachex.Router.Jump do
   In the case of this router the routing state is simply the list
   of nodes being tracked, with duplicate entries removed.
   """
-  @spec init(nodes :: [atom], options :: Keyword.t()) :: [atom]
-  def init(nodes, _options),
-    do: Enum.uniq(nodes)
+  @spec new(nodes :: [atom], options :: Keyword.t()) :: [atom]
+  def new(nodes, _options \\ []) do
+    nodes
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
 
   @doc """
   Retrieve the list of nodes from a routing state.

--- a/lib/cachex/router/local.ex
+++ b/lib/cachex/router/local.ex
@@ -1,0 +1,23 @@
+defmodule Cachex.Router.Local do
+  @moduledoc """
+  Routing implementation for the local node.
+
+  This module acts as the base implementation for routing when *not* being
+  used in a distributed cache. All actions are routed to the current node.
+  """
+  use Cachex.Router
+
+  @doc """
+  Retrieve the list of nodes from a local routing state.
+  """
+  @spec nodes(state :: nil) :: [atom]
+  def nodes(_state),
+    do: [node()]
+
+  @doc """
+  Route a key to a node in a local routing state.
+  """
+  @spec route(state :: nil, key :: any) :: atom
+  def route(_state, _key),
+    do: node()
+end

--- a/lib/cachex/router/mod.ex
+++ b/lib/cachex/router/mod.ex
@@ -1,24 +1,21 @@
-defmodule Cachex.Router.Jump do
+defmodule Cachex.Router.Mod do
   @moduledoc """
-  Routing implementation based on Jump Consistent Hash.
+  Routing implementation based on basic hashing.
 
-  This implementation backed Cachex's distribution in the v3.x lineage, and is
-  suitable for clusters of a static size. Each key is hashed and then slotted
-  against a node in the cluster. Please note that the hash algorithm should
+  This router provides the simplest (and quickest!) implementation for
+  clusters of a static size. Provided keys are hashed and routed to a node
+  via the modulo operation. Please note that the hash algorithm should
   not be relied upon and is not considered part of the public API.
 
   The initialization of this router accepts a `:nodes` option which enables
   the user to define the nodes to route amongst. If this is not provided the
   router will default to detecting a cluster via `Node.self/0` and `Node.list/2`.
-
-  For more information on the algorithm backing this router, please see the
-  appropriate [publication](https://arxiv.org/pdf/1406.2294).
   """
   use Cachex.Router
   alias Cachex.Router
 
   @doc """
-  Initialize a jump hash routing state for a cache.
+  Initialize a modulo routing state for a cache.
 
   ## Options
 
@@ -38,21 +35,21 @@ defmodule Cachex.Router.Jump do
   end
 
   @doc """
-  Retrieve the list of nodes from a jump hash routing state.
+  Retrieve the list of nodes from a modulo routing state.
   """
   @spec nodes(nodes :: [atom]) :: [atom]
   def nodes(nodes),
-    do: nodes
+    do: Enum.sort(nodes)
 
   @doc """
-  Route a key to a node in a jump hash routing state.
+  Route a key to a node in a modulo routing state.
   """
   @spec route(nodes :: [atom], key :: any) :: atom
   def route(nodes, key) do
     slot =
       key
       |> :erlang.phash2()
-      |> Jumper.slot(length(nodes))
+      |> rem(length(nodes))
 
     Enum.at(nodes, slot)
   end

--- a/lib/cachex/router/ring.ex
+++ b/lib/cachex/router/ring.ex
@@ -12,7 +12,8 @@ defmodule Cachex.Router.Ring do
   @doc """
   Initialize a ring using a list of nodes.
   """
-  def init(nodes, _options \\ []) do
+  @spec new(nodes :: [atom], options :: Keyword.t()) :: HashRing.t()
+  def new(nodes, _options \\ []) do
     ring = HashRing.new()
     ring = HashRing.add_nodes(ring, nodes)
     ring
@@ -21,20 +22,32 @@ defmodule Cachex.Router.Ring do
   @doc """
   Retrieve the list of nodes from a ring.
   """
-  defdelegate nodes(ring), to: HashRing, as: :nodes
+  @spec nodes(ring :: HashRing.t()) :: [atom]
+  def nodes(ring) do
+    ring
+    |> HashRing.nodes()
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
 
   @doc """
   Route a provided key to a node in a ring.
   """
-  defdelegate route(ring, key), to: HashRing, as: :key_to_node
+  @spec route(ring :: HashRing.t(), key :: any) :: atom
+  def route(ring, key),
+    do: HashRing.key_to_node(ring, key)
 
   @doc """
   Attach a new node to a ring.
   """
-  defdelegate attach(ring, node), to: HashRing, as: :add_node
+  @spec attach(ring :: HashRing.t(), node :: atom) :: HashRing.t()
+  def attach(ring, node),
+    do: HashRing.add_node(ring, node)
 
   @doc """
   Detach an existing node to a ring.
   """
-  defdelegate detach(ring, node), to: HashRing, as: :remove_node
+  @spec detach(ring :: HashRing.t(), node :: atom) :: HashRing.t()
+  def detach(ring, node),
+    do: HashRing.remove_node(ring, node)
 end

--- a/lib/cachex/router/ring.ex
+++ b/lib/cachex/router/ring.ex
@@ -1,14 +1,40 @@
-# defmodule Cachex.Router.Ring do
-#   use Cachex.Router
+defmodule Cachex.Router.Ring do
+  @moduledoc """
+  Simple routing implementation based on a consistent hash ring.
 
-#   def init(nodes, _options \\ []) do
-#     ring = HashRing.new()
-#     ring = HashRing.add_nodes(ring, nodes)
-#     ring
-#   end
+  This implementation makes use of a hashing ring to better enable
+  modification of the internal node listing. Cachex uses the library
+  [libring](https://github.com/bitwalker/libring) to do the heavy
+  lifting here.
+  """
+  use Cachex.Router
 
-#   defdelegate nodes(ring), to: HashRing, as: :nodes
-#   defdelegate route(ring, key), to: HashRing, as: :key_to_node
-#   defdelegate attach(ring, node), to: HashRing, as: :add_node
-#   defdelegate detach(ring, node), to: HashRing, as: :remove_node
-# end
+  @doc """
+  Initialize a ring using a list of nodes.
+  """
+  def init(nodes, _options \\ []) do
+    ring = HashRing.new()
+    ring = HashRing.add_nodes(ring, nodes)
+    ring
+  end
+
+  @doc """
+  Retrieve the list of nodes from a ring.
+  """
+  defdelegate nodes(ring), to: HashRing, as: :nodes
+
+  @doc """
+  Route a provided key to a node in a ring.
+  """
+  defdelegate route(ring, key), to: HashRing, as: :key_to_node
+
+  @doc """
+  Attach a new node to a ring.
+  """
+  defdelegate attach(ring, node), to: HashRing, as: :add_node
+
+  @doc """
+  Detach an existing node to a ring.
+  """
+  defdelegate detach(ring, node), to: HashRing, as: :remove_node
+end

--- a/lib/cachex/router/ring.ex
+++ b/lib/cachex/router/ring.ex
@@ -1,0 +1,14 @@
+# defmodule Cachex.Router.Ring do
+#   use Cachex.Router
+
+#   def init(nodes, _options \\ []) do
+#     ring = HashRing.new()
+#     ring = HashRing.add_nodes(ring, nodes)
+#     ring
+#   end
+
+#   defdelegate nodes(ring), to: HashRing, as: :nodes
+#   defdelegate route(ring, key), to: HashRing, as: :key_to_node
+#   defdelegate attach(ring, node), to: HashRing, as: :add_node
+#   defdelegate detach(ring, node), to: HashRing, as: :remove_node
+# end

--- a/lib/cachex/services.ex
+++ b/lib/cachex/services.ex
@@ -56,6 +56,7 @@ defmodule Cachex.Services do
     |> Enum.concat(locksmith_spec(cache))
     |> Enum.concat(informant_spec(cache))
     |> Enum.concat(incubator_spec(cache))
+    |> Enum.concat(conductor_spec(cache))
     |> Enum.concat(courier_spec(cache))
     |> Enum.concat(janitor_spec(cache))
   end
@@ -116,6 +117,21 @@ defmodule Cachex.Services do
   ###############
   # Private API #
   ###############
+
+  # Creates a specification for the Conductor service.
+  #
+  # The Conductor service provides a way to dispatch cache calls between
+  # nodes in a distributed cluster. It's a little complicated because a
+  # Conductor's routing logic can be either a separate process or the
+  # same process to avoid unnecessary overhead. If this makes no sense
+  # when you come to read it, that's probably why.
+  defp conductor_spec(cache() = cache),
+    do: [
+      %{
+        id: Services.Conductor,
+        start: {Services.Conductor, :start_link, [cache]}
+      }
+    ]
 
   # Creates a specification for the Courier service.
   #

--- a/lib/cachex/services/conductor.ex
+++ b/lib/cachex/services/conductor.ex
@@ -1,0 +1,311 @@
+defmodule Cachex.Services.Conductor do
+  @moduledoc """
+  Routing module to dispatch Cachex actions to their execution environment.
+
+  This module acts as the single source of dispatch within Cachex. In prior
+  versions the backing actions were called directly from the main interface
+  and were wrapped in macros, which was difficult to maintain and also quite
+  noisy. Now that all execution flows via the router, this is no longer an
+  issue and it also serves as a gateway to distribution in the future.
+  """
+  alias Cachex.Services
+
+  # add some service aliases
+  alias Services.Conductor
+  alias Services.Informant
+  alias Services.Overseer
+
+  # import macro stuff
+  import Cachex.Errors
+  import Cachex.Spec
+
+  ##############
+  # Public API #
+  ##############
+
+  @doc """
+  Executes a previously dispatched action.
+
+  This macro should not be called externally; the only reason it remains
+  public is due to the code injected by the `dispatch/2` macro.
+  """
+  @spec route(Cachex.Spec.cache(), atom, {atom, [any]}) :: any
+  def route(cache(router: router(enabled: false)) = cache, module, call),
+    do: route_local(cache, module, call)
+
+  def route(cache(router: router(enabled: true)) = cache, module, call),
+    do: route_cluster(cache, module, call)
+
+  @doc """
+  Dispatches a call to an appropriate execution environment.
+
+  This acts as a macro just to avoid the overhead of slicing up module
+  names at runtime, when they can be guaranteed at compile time much
+  more easily.
+  """
+  defmacro route(cache, {action, _arguments} = call) do
+    act_name =
+      action
+      |> Kernel.to_string()
+      |> String.replace_trailing("?", "")
+      |> Macro.camelize()
+
+    act_join = :"Elixir.Cachex.Actions.#{act_name}"
+
+    quote do
+      Overseer.enforce unquote(cache) do
+        call = unquote(call)
+        cache = var!(cache)
+        module = unquote(act_join)
+
+        Conductor.route(cache, module, call)
+      end
+    end
+  end
+
+  ###############
+  # Private API #
+  ###############
+
+  # Results merging for distributed cache results.
+  #
+  # Follows these rules:
+  #
+  # - Lists are always concatenated.
+  # - Numbers are always summed.
+  # - Booleans are always AND-ed.
+  # - Maps are always merged (recursively).
+  #
+  # This has to be public due to scopes, but we hide the docs
+  # because we don't really care for anybody else calling it.
+  defp result_merge(left, right) when is_list(left),
+    do: left ++ right
+
+  defp result_merge(left, right) when is_number(left),
+    do: left + right
+
+  defp result_merge(left, right) when is_boolean(left),
+    do: left && right
+
+  defp result_merge(left, right) when is_map(left) do
+    Map.merge(left, right, fn
+      :creation_date, _left, right ->
+        right
+
+      key, left, right when key in [:hit_rate, :miss_rate] ->
+        (left + right) / 2
+
+      _key, left, right ->
+        result_merge(left, right)
+    end)
+  end
+
+  # Provides handling for local actions on this node.
+  #
+  # This will provide handling of notifications across hooks before and after
+  # the execution of an action. This is taken from code formerly in the old
+  # `Cachex.Actions` module, but has been moved here as it's more appropriate.
+  #
+  # If `notify` is set to false, notifications are disabled and the call is
+  # simply executed as is. If `via` is provided, you can override the handle
+  # passed to the hooks (useful for re-use of functions). An example of this
+  # is `decr/4` which simply calls `incr/4` with `via: { :decr, arguments }`.
+  defp route_local(cache, module, {_action, arguments} = call) do
+    option = List.last(arguments)
+    notify = Keyword.get(option, :notify, true)
+
+    message =
+      notify &&
+        case option[:via] do
+          msg when not is_tuple(msg) -> call
+          msg -> msg
+        end
+
+    notify && Informant.broadcast(cache, message)
+    result = apply(module, :execute, [cache | arguments])
+
+    if notify do
+      Informant.broadcast(
+        cache,
+        message,
+        Keyword.get(option, :hook_result, result)
+      )
+    end
+
+    result
+  end
+
+  # actions based on a key
+  @keyed_actions [
+    :del,
+    :exists?,
+    :expire,
+    :fetch,
+    :get,
+    :get_and_update,
+    :incr,
+    :invoke,
+    :put,
+    :refresh,
+    :take,
+    :touch,
+    :ttl,
+    :update
+  ]
+
+  # Provides handling to key-based actions distributed to remote nodes.
+  #
+  # The algorithm here is simple; hash the key and slot the value using JCH into
+  # the total number of slots available (i.e. the count of the nodes). If it comes
+  # out to the local node, just execute the local code, otherwise RPC the base call
+  # to the remote node, and just assume that it'll correctly handle it.
+  defp route_cluster(cache, module, {action, [key | _]} = call)
+       when action in @keyed_actions do
+    cache(router: router(module: router, state: nodes)) = cache
+    route_node(cache, module, call, router.route(nodes, key))
+  end
+
+  # actions which merge outputs
+  @merge_actions [
+    :clear,
+    :count,
+    :empty?,
+    :export,
+    :import,
+    :keys,
+    :purge,
+    :reset,
+    :size,
+    :stats
+  ]
+
+  # Provides handling of cross-node actions distributed over remote nodes.
+  #
+  # This will do an RPC call across all nodes to fetch their results and merge
+  # them with the results on the local node. The hooks will only be notified
+  # on the local node, due to an annoying recursion issue when handling the
+  # same across all nodes - seems to provide better logic though.
+  defp route_cluster(cache, module, {action, arguments} = call)
+       when action in @merge_actions do
+    # fetch the nodes from the cluster state
+    cache(router: router(module: router, state: state)) = cache
+
+    # all calls have options we can use
+    options = List.last(arguments)
+
+    # can force local node setting local: true
+    results =
+      case Keyword.get(options, :local) do
+        true ->
+          []
+
+        _any ->
+          # don't want to execute on the local node
+          other_nodes =
+            state
+            |> router.nodes()
+            |> List.delete(node())
+
+          # execute the call on all other nodes
+          {results, _} =
+            :rpc.multicall(
+              other_nodes,
+              module,
+              :execute,
+              [cache | arguments]
+            )
+
+          results
+      end
+
+    # execution on the local node, using the local macros and then unpack
+    {:ok, result} = route_local(cache, module, call)
+
+    # results merge
+    merge_result =
+      results
+      |> Enum.map(&elem(&1, 1))
+      |> Enum.reduce(result, &result_merge/2)
+
+    # return after merge
+    {:ok, merge_result}
+  end
+
+  # actions which always run locally
+  @local_actions [:dump, :inspect, :load, :warm]
+
+  # Provides handling of `:inspect` operations.
+  #
+  # These operations are guaranteed to run on the local nodes.
+  defp route_cluster(cache, module, {action, _arguments} = call)
+       when action in @local_actions,
+       do: route_local(cache, module, call)
+
+  # Provides handling of `:put_many` operations.
+  #
+  # These operations can only execute if their keys slot to the same remote nodes.
+  defp route_cluster(cache, module, {:put_many, _arguments} = call),
+    do: route_batch(cache, module, call, &elem(&1, 0))
+
+  # Provides handling of `:transaction` operations.
+  #
+  # These operations can only execute if their keys slot to the same remote nodes.
+  defp route_cluster(cache, module, {:transaction, [keys | _]} = call) do
+    case keys do
+      [] -> route_local(cache, module, call)
+      _ -> route_batch(cache, module, call, & &1)
+    end
+  end
+
+  # Any other actions are explicitly disabled in distributed environments.
+  defp route_cluster(_cache, _module, _call),
+    do: error(:non_distributed)
+
+  # Calls a slot for the provided cache action if all keys slot to the same node.
+  #
+  # This is a delegate handler for `route_node/4`, but ensures that all keys slot to the
+  # same node to avoid the case where we have to fork a call out internally.
+  defp route_batch(cache, module, {_action, [keys | _]} = call, mapper) do
+    # map all keys to a slot in the nodes list
+    cache(router: router(module: router, state: state)) = cache
+    slots = Enum.map(keys, &router.route(state, mapper.(&1)))
+
+    # unique to avoid dups
+    case Enum.uniq(slots) do
+      # if there's a single slot it's safe to continue with the call to the remote
+      [slot] ->
+        route_node(cache, module, call, slot)
+
+      # otherwise, cross_slot errors!
+      _disable ->
+        error(:cross_slot)
+    end
+  end
+
+  # Calls a node for the provided cache action.
+  #
+  # This will determine a local slot and delegate locally if so, bypassing
+  # any RPC calls in order to gain a slight bit of performance.
+  defp route_node(cache, module, {action, arguments} = call, node) do
+    current = node()
+    cache(name: name) = cache
+
+    case node do
+      ^current ->
+        route_local(cache, module, call)
+
+      targeted ->
+        result =
+          :rpc.call(
+            targeted,
+            Cachex,
+            action,
+            [name | arguments]
+          )
+
+        with {:badrpc, reason} <- result do
+          {:error, reason}
+        end
+    end
+  end
+end

--- a/lib/cachex/services/conductor.ex
+++ b/lib/cachex/services/conductor.ex
@@ -44,6 +44,7 @@ defmodule Cachex.Services.Conductor do
   more easily.
   """
   defmacro route(cache, {action, _arguments} = call) do
+    # coveralls-ignore-start
     act_name =
       action
       |> Kernel.to_string()
@@ -51,6 +52,7 @@ defmodule Cachex.Services.Conductor do
       |> Macro.camelize()
 
     act_join = :"Elixir.Cachex.Actions.#{act_name}"
+    # coveralls-ignore-stop
 
     quote do
       Overseer.enforce unquote(cache) do

--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -33,7 +33,6 @@ defmodule Cachex.Spec do
             fallback: fallback,
             hooks: hooks,
             limit: limit,
-            nodes: [atom],
             ordered: boolean,
             router: router,
             transactions: boolean,
@@ -101,7 +100,7 @@ defmodule Cachex.Spec do
   # Record specification for a router instance
   @type router ::
           record(:router,
-            enabled: boolean,
+            options: Keyword.t(),
             module: atom,
             state: any
           )
@@ -135,7 +134,6 @@ defmodule Cachex.Spec do
     fallback: nil,
     hooks: nil,
     limit: nil,
-    nodes: [],
     ordered: false,
     router: nil,
     transactions: false,
@@ -268,9 +266,8 @@ defmodule Cachex.Spec do
   values inside this structure are for internal use and will be overwritten as needed.
   """
   defrecord :router,
-    enabled: false,
     options: [],
-    module: Cachex.Router.Jump,
+    module: Cachex.Router.Local,
     state: nil
 
   @doc """

--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -34,7 +34,6 @@ defmodule Cachex.Spec do
             fallback: fallback,
             hooks: hooks,
             limit: limit,
-            nodes: [atom],
             ordered: boolean,
             transactions: boolean,
             warmers: [warmer]
@@ -45,7 +44,7 @@ defmodule Cachex.Spec do
           record(:cluster,
             enabled: boolean,
             router: (any, any -> atom),
-            nodes: any
+            state: any
           )
 
   # Record specification for a command instance
@@ -135,7 +134,6 @@ defmodule Cachex.Spec do
     fallback: nil,
     hooks: nil,
     limit: nil,
-    nodes: [],
     ordered: false,
     transactions: false,
     warmers: []
@@ -143,7 +141,7 @@ defmodule Cachex.Spec do
   defrecord :cluster,
     enabled: false,
     router: nil,
-    nodes: nil
+    state: nil
 
   @doc """
   Creates a command record from the provided values.

--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -27,6 +27,7 @@ defmodule Cachex.Spec do
   @type cache ::
           record(:cache,
             name: atom,
+            cluster: cluster,
             commands: map,
             compressed: boolean,
             expiration: expiration,
@@ -37,6 +38,14 @@ defmodule Cachex.Spec do
             ordered: boolean,
             transactions: boolean,
             warmers: [warmer]
+          )
+
+  # Record specification for a cluster instance
+  @type cluster ::
+          record(:cluster,
+            enabled: boolean,
+            router: (any, any -> atom),
+            nodes: any
           )
 
   # Record specification for a command instance
@@ -119,6 +128,7 @@ defmodule Cachex.Spec do
   """
   defrecord :cache,
     name: nil,
+    cluster: nil,
     commands: %{},
     compressed: false,
     expiration: nil,
@@ -129,6 +139,11 @@ defmodule Cachex.Spec do
     ordered: false,
     transactions: false,
     warmers: []
+
+  defrecord :cluster,
+    enabled: false,
+    router: nil,
+    nodes: nil
 
   @doc """
   Creates a command record from the provided values.
@@ -272,6 +287,12 @@ defmodule Cachex.Spec do
   """
   @spec cache(cache, Keyword.t()) :: cache
   defmacro cache(record, args)
+
+  @doc """
+  Updates a cluster record from the provided values.
+  """
+  @spec cluster(cluster, Keyword.t()) :: cluster
+  defmacro cluster(record, args)
 
   @doc """
   Updates a command record from the provided values.

--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -27,24 +27,17 @@ defmodule Cachex.Spec do
   @type cache ::
           record(:cache,
             name: atom,
-            cluster: cluster,
             commands: map,
             compressed: boolean,
             expiration: expiration,
             fallback: fallback,
             hooks: hooks,
             limit: limit,
+            nodes: [atom],
             ordered: boolean,
+            router: router,
             transactions: boolean,
             warmers: [warmer]
-          )
-
-  # Record specification for a cluster instance
-  @type cluster ::
-          record(:cluster,
-            enabled: boolean,
-            router: (any, any -> atom),
-            state: any
           )
 
   # Record specification for a command instance
@@ -105,6 +98,14 @@ defmodule Cachex.Spec do
             options: Keyword.t()
           )
 
+  # Record specification for a router instance
+  @type router ::
+          record(:router,
+            enabled: boolean,
+            module: atom,
+            state: any
+          )
+
   # Record specification for a cache warmer
   @type warmer ::
           record(:warmer,
@@ -134,14 +135,11 @@ defmodule Cachex.Spec do
     fallback: nil,
     hooks: nil,
     limit: nil,
+    nodes: [],
     ordered: false,
+    router: nil,
     transactions: false,
     warmers: []
-
-  defrecord :cluster,
-    enabled: false,
-    router: nil,
-    state: nil
 
   @doc """
   Creates a command record from the provided values.
@@ -261,6 +259,21 @@ defmodule Cachex.Spec do
     options: []
 
   @doc """
+  Creates a router record from the provided values.
+
+  A router record reprsents routing within a distributed cache. Each router record should have a
+  valid routing module provided, which correct implements the behaviour defined in `Cachex.Router`.
+
+  Options to be passed on router state initialization can also be provided, but note that all other
+  values inside this structure are for internal use and will be overwritten as needed.
+  """
+  defrecord :router,
+    enabled: false,
+    options: [],
+    module: Cachex.Router.Jump,
+    state: nil
+
+  @doc """
   Creates a warmer record from the provided values.
 
   A warmer record represents cache warmer processes to be run to populate keys.
@@ -285,12 +298,6 @@ defmodule Cachex.Spec do
   """
   @spec cache(cache, Keyword.t()) :: cache
   defmacro cache(record, args)
-
-  @doc """
-  Updates a cluster record from the provided values.
-  """
-  @spec cluster(cluster, Keyword.t()) :: cluster
-  defmacro cluster(record, args)
 
   @doc """
   Updates a command record from the provided values.
@@ -333,6 +340,12 @@ defmodule Cachex.Spec do
   """
   @spec limit(limit, Keyword.t()) :: limit
   defmacro limit(record, args)
+
+  @doc """
+  Updates a router record from the provided values.
+  """
+  @spec router(router, Keyword.t()) :: router
+  defmacro router(record, args)
 
   @doc """
   Updates a warmer record from the provided values.

--- a/lib/cachex/spec/validator.ex
+++ b/lib/cachex/spec/validator.ex
@@ -136,17 +136,14 @@ defmodule Cachex.Spec.Validator do
   # This will validate the correctly implemented `Cachex.Router` behaviour
   # and confirm that the provided options are a keyword list.
   def valid?(:router, router() = router) do
-    router(options: options, module: module, enabled: enabled) = router
+    router(options: options, module: module) = router
 
     check1 = behaviour?(module, Cachex.Router)
-    check2 = check1 and is_boolean(enabled)
-    check3 = check2 and {:new, 2} in module.__info__(:functions)
-    check4 = check3 and {:nodes, 1} in module.__info__(:functions)
-    check5 = check4 and {:route, 2} in module.__info__(:functions)
-    check6 = check5 and {:attach, 2} in module.__info__(:functions)
-    check7 = check6 and {:detach, 2} in module.__info__(:functions)
-    check8 = check7 and Keyword.keyword?(options)
-    check8
+    check2 = check1 and {:init, 2} in module.__info__(:functions)
+    check3 = check2 and {:nodes, 1} in module.__info__(:functions)
+    check4 = check3 and {:route, 2} in module.__info__(:functions)
+    check5 = check4 and Keyword.keyword?(options)
+    check5
   end
 
   # Validates a warmer specification record.

--- a/lib/cachex/spec/validator.ex
+++ b/lib/cachex/spec/validator.ex
@@ -131,6 +131,24 @@ defmodule Cachex.Spec.Validator do
     check6
   end
 
+  # Validates a router specification record.
+  #
+  # This will validate the correctly implemented `Cachex.Router` behaviour
+  # and confirm that the provided options are a keyword list.
+  def valid?(:router, router() = router) do
+    router(options: options, module: module, enabled: enabled) = router
+
+    check1 = behaviour?(module, Cachex.Router)
+    check2 = check1 and is_boolean(enabled)
+    check3 = check2 and {:init, 2} in module.__info__(:functions)
+    check4 = check3 and {:nodes, 1} in module.__info__(:functions)
+    check5 = check4 and {:route, 2} in module.__info__(:functions)
+    check6 = check5 and {:attach, 2} in module.__info__(:functions)
+    check7 = check6 and {:detach, 2} in module.__info__(:functions)
+    check8 = check7 and Keyword.keyword?(options)
+    check8
+  end
+
   # Validates a warmer specification record.
   #
   # This will validate that the provided module correctly implements the

--- a/lib/cachex/spec/validator.ex
+++ b/lib/cachex/spec/validator.ex
@@ -140,7 +140,7 @@ defmodule Cachex.Spec.Validator do
 
     check1 = behaviour?(module, Cachex.Router)
     check2 = check1 and is_boolean(enabled)
-    check3 = check2 and {:init, 2} in module.__info__(:functions)
+    check3 = check2 and {:new, 2} in module.__info__(:functions)
     check4 = check3 and {:nodes, 1} in module.__info__(:functions)
     check5 = check4 and {:route, 2} in module.__info__(:functions)
     check6 = check5 and {:attach, 2} in module.__info__(:functions)

--- a/mix.exs
+++ b/mix.exs
@@ -95,6 +95,7 @@ defmodule Cachex.Mixfile do
       # Production dependencies
       {:eternal, "~> 1.2"},
       {:jumper, "~> 1.0"},
+      {:libring, "~> 1.6"},
       {:sleeplocks, "~> 1.1"},
       {:unsafe, "~> 1.0"},
       # Testing dependencies

--- a/test/cachex/actions/fetch_test.exs
+++ b/test/cachex/actions/fetch_test.exs
@@ -191,8 +191,8 @@ defmodule Cachex.Actions.FetchTest do
     # create a test agent to hold our test state
     {:ok, agent} = Agent.start_link(fn -> %{} end)
 
-    # execute 100 fetches
-    for idx <- 1..100 do
+    # execute 1000 fetches
+    for idx <- 1..1000 do
       # with a unique key
       key = "key_#{idx}"
       count = System.schedulers_online() * 2
@@ -224,6 +224,6 @@ defmodule Cachex.Actions.FetchTest do
       end)
 
     # all should have been called just once
-    assert %{1 => 100} == calls
+    assert %{1 => 1000} == calls
   end
 end

--- a/test/cachex/actions/transaction_test.exs
+++ b/test/cachex/actions/transaction_test.exs
@@ -38,7 +38,7 @@ defmodule Cachex.Actions.TransactionTest do
 
     # execute a broken transaction
     result1 =
-      Cachex.transaction(cache, [], fn _state ->
+      Cachex.transaction(cache, [], fn ->
         raise ArgumentError, message: "Error message"
       end)
 
@@ -47,7 +47,7 @@ defmodule Cachex.Actions.TransactionTest do
 
     # ensure a new transaction executes normally
     result2 =
-      Cachex.transaction(cache, [], fn _state ->
+      Cachex.transaction(cache, [], fn ->
         Cachex.Services.Locksmith.transaction?()
       end)
 

--- a/test/cachex/actions/transaction_test.exs
+++ b/test/cachex/actions/transaction_test.exs
@@ -88,7 +88,8 @@ defmodule Cachex.Actions.TransactionTest do
     {cache, _nodes} = Helper.create_cache_cluster(2)
 
     # we know that 2 & 3 hash to the same slots
-    {:ok, result} = Cachex.transaction(cache, [2, 3], &:erlang.phash2/1)
+    {:ok, result} = Cachex.transaction(cache, [], &:erlang.phash2/1)
+    {:ok, ^result} = Cachex.transaction(cache, [2, 3], &:erlang.phash2/1)
 
     # check the result phashed ok
     assert(result > 0 && is_integer(result))

--- a/test/cachex/errors_test.exs
+++ b/test/cachex/errors_test.exs
@@ -17,6 +17,7 @@ defmodule Cachex.ErrorsTest do
       invalid_nodes: "Invalid nodes list provided",
       invalid_option: "Invalid option syntax provided",
       invalid_pairs: "Invalid insertion pairs provided",
+      invalid_router: "Invalid router definition provided",
       invalid_warmer: "Invalid warmer definition provided",
       janitor_disabled: "Specified janitor process running",
       no_cache: "Specified cache not running",

--- a/test/cachex/errors_test.exs
+++ b/test/cachex/errors_test.exs
@@ -14,7 +14,6 @@ defmodule Cachex.ErrorsTest do
       invalid_limit: "Invalid limit fields provided",
       invalid_match: "Invalid match specification provided",
       invalid_name: "Invalid cache name provided",
-      invalid_nodes: "Invalid nodes list provided",
       invalid_option: "Invalid option syntax provided",
       invalid_pairs: "Invalid insertion pairs provided",
       invalid_router: "Invalid router definition provided",

--- a/test/cachex/options_test.exs
+++ b/test/cachex/options_test.exs
@@ -355,17 +355,17 @@ defmodule Cachex.OptionsTest do
     {:ok, cache(router: router1)} = Cachex.Options.parse(name, [])
 
     {:ok, cache(router: router2)} =
-      Cachex.Options.parse(name, router: Cachex.Router.Ring)
+      Cachex.Options.parse(name, router: Cachex.Router.Mod)
 
     # parse out invalid hook combinations
     {:error, msg} = Cachex.Options.parse(name, router: "[router]")
     {:error, ^msg} = Cachex.Options.parse(name, router: router(module: Missing))
 
     # check the router for the first state and the default value
-    assert(router1 == router(module: Cachex.Router.Jump))
+    assert(router1 == router(module: Cachex.Router.Local))
 
     # check the router in the second state
-    assert(router2 == router(module: Cachex.Router.Ring))
+    assert(router2 == router(module: Cachex.Router.Mod))
 
     # check the invalid router message
     assert(msg == :invalid_router)

--- a/test/cachex/options_test.exs
+++ b/test/cachex/options_test.exs
@@ -135,27 +135,6 @@ defmodule Cachex.OptionsTest do
     refute comp3
   end
 
-  # This test will verify the parsing of compression flags to determine whether
-  # a cache has them enabled or disabled. This is simply checking whether the flag
-  # is set to true or false, and the default.
-  test "parsing :ordered flags" do
-    # grab a cache name
-    name = Helper.create_name()
-
-    # parse our values as options
-    {:ok, cache(ordered: ordered1)} =
-      Cachex.Options.parse(name, ordered: true)
-
-    {:ok, cache(ordered: ordered2)} =
-      Cachex.Options.parse(name, ordered: false)
-
-    {:ok, cache(ordered: ordered3)} = Cachex.Options.parse(name, [])
-
-    assert ordered1
-    refute ordered2
-    refute ordered3
-  end
-
   # This test verifies the parsing of TTL related flags. We have to test various
   # combinations of :ttl_interval and :default_ttl to verify each state correctly.
   test "parsing :expiration flags" do
@@ -343,6 +322,53 @@ defmodule Cachex.OptionsTest do
 
     # check the fourth causes an error
     assert(msg == :invalid_limit)
+  end
+
+  # This test will verify the parsing of compression flags to determine whether
+  # a cache has them enabled or disabled. This is simply checking whether the flag
+  # is set to true or false, and the default.
+  test "parsing :ordered flags" do
+    # grab a cache name
+    name = Helper.create_name()
+
+    # parse our values as options
+    {:ok, cache(ordered: ordered1)} =
+      Cachex.Options.parse(name, ordered: true)
+
+    {:ok, cache(ordered: ordered2)} =
+      Cachex.Options.parse(name, ordered: false)
+
+    {:ok, cache(ordered: ordered3)} = Cachex.Options.parse(name, [])
+
+    assert ordered1
+    refute ordered2
+    refute ordered3
+  end
+
+  # This test will ensure that we can parse router values successfully. Routers
+  # can be provided as either an atom module name, or a router struct.
+  test "parsing :router flags" do
+    # grab a cache name
+    name = Helper.create_name()
+
+    # parse out valid router combinations
+    {:ok, cache(router: router1)} = Cachex.Options.parse(name, [])
+
+    {:ok, cache(router: router2)} =
+      Cachex.Options.parse(name, router: Cachex.Router.Ring)
+
+    # parse out invalid hook combinations
+    {:error, msg} = Cachex.Options.parse(name, router: "[router]")
+    {:error, ^msg} = Cachex.Options.parse(name, router: router(module: Missing))
+
+    # check the router for the first state and the default value
+    assert(router1 == router(module: Cachex.Router.Jump))
+
+    # check the router in the second state
+    assert(router2 == router(module: Cachex.Router.Ring))
+
+    # check the invalid router message
+    assert(msg == :invalid_router)
   end
 
   # This test will verify the ability to record stats in a state. This option

--- a/test/cachex/policy/lrw/evented_test.exs
+++ b/test/cachex/policy/lrw/evented_test.exs
@@ -47,7 +47,7 @@ defmodule Cachex.Policy.LRW.EventedTest do
     # retrieve the cache state
     state = Services.Overseer.retrieve(cache)
 
-    # add 1000 keys to the cache
+    # add 100 keys to the cache
     for x <- 1..100 do
       # add the entry to the cache
       {:ok, true} = Cachex.put(state, x, x)
@@ -64,6 +64,18 @@ defmodule Cachex.Policy.LRW.EventedTest do
 
     # flush all existing hook events
     Helper.flush()
+
+    # run a no-op fetch to verify no change
+    {:ignore, nil} =
+      Cachex.fetch(state, 101, fn ->
+        {:ignore, nil}
+      end)
+
+    # retrieve the cache size
+    size2 = Cachex.size!(cache)
+
+    # verify the cache size
+    assert(size2 == 100)
 
     # add a new key to the cache to trigger evictions
     {:ok, true} = Cachex.put(state, 101, 101)

--- a/test/cachex/router/jump_test.exs
+++ b/test/cachex/router/jump_test.exs
@@ -1,0 +1,29 @@
+defmodule Cachex.Router.JumpTest do
+  use CachexCase
+
+  test "routing keys within a jump router" do
+    # create a router from three node names
+    router = Router.Jump.new([:a, :b, :c])
+
+    # test that we can route to expected nodes
+    assert Router.Jump.nodes(router) == [:a, :b, :c]
+    assert Router.Jump.route(router, "elixir") == :b
+    assert Router.Jump.route(router, "erlang") == :c
+  end
+
+  test "attaching a node causes an error" do
+    assert_raise(RuntimeError, "Router does not support node addition", fn ->
+      [node()]
+      |> Router.Jump.new()
+      |> Router.Jump.attach(node())
+    end)
+  end
+
+  test "detaching a node causes an error" do
+    assert_raise(RuntimeError, "Router does not support node removal", fn ->
+      [node()]
+      |> Router.Jump.new()
+      |> Router.Jump.detach(node())
+    end)
+  end
+end

--- a/test/cachex/router/local_test.exs
+++ b/test/cachex/router/local_test.exs
@@ -1,0 +1,19 @@
+defmodule Cachex.Router.LocalTest do
+  use CachexCase
+
+  test "routing keys via a local router" do
+    # create a test cache
+    cache = Helper.create_cache(router: Cachex.Router.Local)
+
+    # convert the name to a cache and sort
+    cache = Services.Overseer.retrieve(cache)
+
+    # fetch the router state after initialize
+    cache(router: router(state: state)) = cache
+
+    # test that we can route to expected nodes
+    assert Services.Conductor.nodes(cache) == {:ok, [node()]}
+    assert Cachex.Router.Local.route(state, "elixir") == node()
+    assert Cachex.Router.Local.route(state, "erlang") == node()
+  end
+end

--- a/test/cachex/router/mod_test.exs
+++ b/test/cachex/router/mod_test.exs
@@ -1,11 +1,11 @@
-defmodule Cachex.Router.JumpTest do
+defmodule Cachex.Router.ModTest do
   use CachexCase
 
-  test "routing keys via a jump router" do
+  test "routing keys via a modulo router" do
     # create a test cache cluster for nodes
     {cache, nodes} =
       Helper.create_cache_cluster(3,
-        router: Cachex.Router.Jump
+        router: Cachex.Router.Mod
       )
 
     # convert the name to a cache and sort
@@ -17,11 +17,11 @@ defmodule Cachex.Router.JumpTest do
 
     # test that we can route to expected nodes
     assert Services.Conductor.nodes(cache) == {:ok, nodes}
-    assert Cachex.Router.Jump.route(state, "elixir") == Enum.at(nodes, 1)
-    assert Cachex.Router.Jump.route(state, "erlang") == Enum.at(nodes, 2)
+    assert Cachex.Router.Mod.route(state, "elixir") == Enum.at(nodes, 1)
+    assert Cachex.Router.Mod.route(state, "erlang") == Enum.at(nodes, 0)
   end
 
-  test "routing keys via a jump router with defined nodes" do
+  test "routing keys via a modulo router with defined nodes" do
     # create our nodes
     nodes = [:a, :b, :c]
 
@@ -41,7 +41,7 @@ defmodule Cachex.Router.JumpTest do
 
     # test that we can route to expected nodes
     assert Services.Conductor.nodes(cache) == {:ok, nodes}
-    assert Cachex.Router.Jump.route(state, "elixir") == Enum.at(nodes, 1)
-    assert Cachex.Router.Jump.route(state, "erlang") == Enum.at(nodes, 2)
+    assert Cachex.Router.Mod.route(state, "elixir") == Enum.at(nodes, 1)
+    assert Cachex.Router.Mod.route(state, "erlang") == Enum.at(nodes, 0)
   end
 end

--- a/test/cachex/router/ring_test.exs
+++ b/test/cachex/router/ring_test.exs
@@ -1,0 +1,42 @@
+defmodule Cachex.Router.RingTest do
+  use CachexCase
+
+  test "routing keys within a ring router" do
+    # create a router from three node names
+    router = Router.Ring.new([:a, :b, :c])
+
+    # test that we can route to expected nodes
+    assert Router.Ring.nodes(router) == [:a, :b, :c]
+    assert Router.Ring.route(router, "elixir") == :c
+    assert Router.Ring.route(router, "erlang") == :b
+  end
+
+  test "attaching and detaching node in a ring router" do
+    # create a router from three node names
+    router = Router.Ring.new([:a, :b, :c])
+
+    # verify the routing of various keys
+    assert Router.Ring.nodes(router) == [:a, :b, :c]
+    assert Router.Ring.route(router, "elixir") == :c
+    assert Router.Ring.route(router, "erlang") == :b
+    assert Router.Ring.route(router, "fsharp") == :c
+
+    # attach a new node :d to the router
+    router = Router.Ring.attach(router, :d)
+
+    # route the same keys again, fsharp is resharded
+    assert Router.Ring.nodes(router) == [:a, :b, :c, :d]
+    assert Router.Ring.route(router, "elixir") == :c
+    assert Router.Ring.route(router, "erlang") == :b
+    assert Router.Ring.route(router, "fsharp") == :d
+
+    # remove the node :d from the router
+    router = Router.Ring.detach(router, :d)
+
+    # the key fsharp is routed back to the initial
+    assert Router.Ring.nodes(router) == [:a, :b, :c]
+    assert Router.Ring.route(router, "elixir") == :c
+    assert Router.Ring.route(router, "erlang") == :b
+    assert Router.Ring.route(router, "fsharp") == :c
+  end
+end

--- a/test/cachex/router_test.exs
+++ b/test/cachex/router_test.exs
@@ -1,35 +1,3 @@
 defmodule Cachex.RouterTest do
   use CachexCase
-
-  test "default Router implementations" do
-    # create a router from three node names
-    router = __MODULE__.DefaultRouter.new([:a, :b, :c])
-
-    # check we can route and fetch the node list
-    assert __MODULE__.DefaultRouter.nodes(router) == [:a, :b, :c]
-    assert __MODULE__.DefaultRouter.route(router, "") == :a
-
-    # verify that addition of a node is not applicable by default
-    assert_raise(RuntimeError, "Router does not support node addition", fn ->
-      __MODULE__.DefaultRouter.attach(router, node())
-    end)
-
-    # verify that removal of a node is not applicable by default
-    assert_raise(RuntimeError, "Router does not support node removal", fn ->
-      __MODULE__.DefaultRouter.detach(router, node())
-    end)
-  end
-
-  defmodule DefaultRouter do
-    use Cachex.Router
-
-    def new(nodes, _opts \\ []),
-      do: nodes
-
-    def nodes(nodes),
-      do: nodes
-
-    def route(nodes, _key),
-      do: Enum.at(nodes, 0)
-  end
 end

--- a/test/cachex/router_test.exs
+++ b/test/cachex/router_test.exs
@@ -1,0 +1,35 @@
+defmodule Cachex.RouterTest do
+  use CachexCase
+
+  test "default Router implementations" do
+    # create a router from three node names
+    router = __MODULE__.DefaultRouter.new([:a, :b, :c])
+
+    # check we can route and fetch the node list
+    assert __MODULE__.DefaultRouter.nodes(router) == [:a, :b, :c]
+    assert __MODULE__.DefaultRouter.route(router, "") == :a
+
+    # verify that addition of a node is not applicable by default
+    assert_raise(RuntimeError, "Router does not support node addition", fn ->
+      __MODULE__.DefaultRouter.attach(router, node())
+    end)
+
+    # verify that removal of a node is not applicable by default
+    assert_raise(RuntimeError, "Router does not support node removal", fn ->
+      __MODULE__.DefaultRouter.detach(router, node())
+    end)
+  end
+
+  defmodule DefaultRouter do
+    use Cachex.Router
+
+    def new(nodes, _opts \\ []),
+      do: nodes
+
+    def nodes(nodes),
+      do: nodes
+
+    def route(nodes, _key),
+      do: Enum.at(nodes, 0)
+  end
+end

--- a/test/cachex/services_test.exs
+++ b/test/cachex/services_test.exs
@@ -22,6 +22,7 @@ defmodule Cachex.ServicesTest do
              },
              %{id: Services.Informant, start: {Services.Informant, _, _}},
              %{id: Services.Incubator, start: {Services.Incubator, _, _}},
+             %{id: Services.Conductor, start: {Services.Conductor, _, _}},
              %{id: Services.Courier, start: {Services.Courier, _, _}},
              %{id: Services.Janitor, start: {Services.Janitor, _, _}}
            ] = Services.cache_spec(cache)
@@ -41,6 +42,7 @@ defmodule Cachex.ServicesTest do
              },
              %{id: Services.Informant, start: {Services.Informant, _, _}},
              %{id: Services.Incubator, start: {Services.Incubator, _, _}},
+             %{id: Services.Conductor, start: {Services.Conductor, _, _}},
              %{id: Services.Courier, start: {Services.Courier, _, _}}
            ] = Services.cache_spec(cache)
   end

--- a/test/cachex/spec/validator_test.exs
+++ b/test/cachex/spec/validator_test.exs
@@ -206,6 +206,32 @@ defmodule Cachex.Spec.ValidatorTest do
     refute Validator.valid?(:limit, limit8)
   end
 
+  test "validation of router records" do
+    # define some valid records
+    router1 = router(module: Router.Jump)
+    router2 = router(module: Router.Jump, options: [])
+    router3 = router(module: Router.Jump, enabled: true)
+
+    # ensure all records are valid
+    assert Validator.valid?(:router, router1)
+    assert Validator.valid?(:router, router2)
+    assert Validator.valid?(:router, router3)
+
+    # define some invalid records
+    router5 = router(module: " ")
+    router6 = router(module: :missing)
+    router7 = router(module: __MODULE__)
+    router8 = router(module: Router.Jump, options: "")
+    router9 = router(module: Router.Jump, enabled: "yes")
+
+    # ensure all records are invalid
+    refute Validator.valid?(:router, router5)
+    refute Validator.valid?(:router, router6)
+    refute Validator.valid?(:router, router7)
+    refute Validator.valid?(:router, router8)
+    refute Validator.valid?(:router, router9)
+  end
+
   test "validation of warmer records" do
     # create a warmer for validation
     Helper.create_warmer(:validator_warmer, 1000, fn _ ->

--- a/test/cachex/spec/validator_test.exs
+++ b/test/cachex/spec/validator_test.exs
@@ -208,9 +208,9 @@ defmodule Cachex.Spec.ValidatorTest do
 
   test "validation of router records" do
     # define some valid records
-    router1 = router(module: Router.Jump)
-    router2 = router(module: Router.Jump, options: [])
-    router3 = router(module: Router.Jump, enabled: true)
+    router1 = router()
+    router2 = router(module: Cachex.Router.Jump)
+    router3 = router(module: Cachex.Router.Jump, options: [])
 
     # ensure all records are valid
     assert Validator.valid?(:router, router1)
@@ -218,18 +218,16 @@ defmodule Cachex.Spec.ValidatorTest do
     assert Validator.valid?(:router, router3)
 
     # define some invalid records
-    router5 = router(module: " ")
-    router6 = router(module: :missing)
-    router7 = router(module: __MODULE__)
-    router8 = router(module: Router.Jump, options: "")
-    router9 = router(module: Router.Jump, enabled: "yes")
+    router4 = router(module: " ")
+    router5 = router(module: :missing)
+    router6 = router(module: __MODULE__)
+    router7 = router(module: Cachex.Router.Jump, options: "")
 
     # ensure all records are invalid
+    refute Validator.valid?(:router, router4)
     refute Validator.valid?(:router, router5)
     refute Validator.valid?(:router, router6)
     refute Validator.valid?(:router, router7)
-    refute Validator.valid?(:router, router8)
-    refute Validator.valid?(:router, router9)
   end
 
   test "validation of warmer records" do

--- a/test/lib/cachex_case.ex
+++ b/test/lib/cachex_case.ex
@@ -7,6 +7,7 @@ defmodule CachexCase do
       alias CachexCase.ExecuteHook
       alias CachexCase.ForwardHook
       alias CachexCase.Helper
+      alias Cachex.Router
       alias Cachex.Services
 
       import Cachex.Spec

--- a/test/lib/cachex_case.ex
+++ b/test/lib/cachex_case.ex
@@ -7,7 +7,6 @@ defmodule CachexCase do
       alias CachexCase.ExecuteHook
       alias CachexCase.ForwardHook
       alias CachexCase.Helper
-      alias Cachex.Router
       alias Cachex.Services
 
       import Cachex.Spec

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,8 +7,8 @@ Application.ensure_all_started(:cachex)
 |> Enum.filter(&(!File.dir?(&1)))
 |> Enum.each(&Code.require_file/1)
 
-# start ExUnit!
-ExUnit.start()
+# start ExUnit with skips
+ExUnit.start(exclude: [:skip])
 
 # internal module
 defmodule TestHelper do


### PR DESCRIPTION
Fixes #246 and #344 and #345 :)

This PR introduces customizable routing modules for distributed caches and will also include documentation updates based on the comments in #246 (namely https://github.com/whitfin/cachex/issues/246#issuecomment-2043036330). It should be noted that the next version of Cachex will be v4.0.0 so we are free to make breaking changes here.

There is a lot in here, but the gist is that you can now provide an implementation of `Cachex.Router` to dictate exactly how your keys are assigned to nodes in your cluster. Routers can either be synchronous state, or they can delegate to other linked processes. There are four routers included in this PR:

* `Cachex.Router.Local`
  * Routes keys to the local node
  * Does not accept any options
  * This is the default router
* `Cachex.Router.Mod`
  * Routes keys using basic hashing (i.e. `hash(key) % len(nodes)`)
  * Included as reference and to add more test coverage
  * The quickest remote implementation
* `Cachex.Router.Jump`
  * Routes keys using Jump Consistent hash
  * Accepts a list of nodes as options
  * Same logic as Cachex v3.x
* `Cachex.Router.Ring`
  * Routes keys using a hash ring
  * Can dynamically scale to added/removed nodes
  * Delegates to [libring](https://github.com/bitwalker/libring)
  * Accepts all of the same options as `libring`

Each of these routers (except `Cachex.Router.Local`) can be configured to use the currently connected nodes, rather than providing them. The way to do this differs per router, so make sure to visit them for docs (although I'll be writing a new "distribution" guide based on these prior to v4.x).

I previously wrote that I would add two functions to the Cachex API to allow addition/removal of nodes, but I don't think this makes sense now that we can configure routers independently. If we need additional APIs for this in future, happy to add them but they don't seem necessary.

The old `Cachex.Router` module was moved into a service in `Cachex.Services.Conductor` to better fit the new role, and to allow `Cachex.Router` to focus on behaviour. 

The `:nodes` option has also been removed from Cachex's main API, because now it's an option on (some of) the Router implementations. This is also much cleaner, IMO.