### PR TITLE
Refactor test modules and naming conventions

### DIFF
--- a/test/cachex/actions/clear_test.exs
+++ b/test/cachex/actions/clear_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.ClearTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies that a cache can be successfully cleared. We fill the cache
   # and clear it, verifying that the entries were removed successfully. We also

--- a/test/cachex/actions/clear_test.exs
+++ b/test/cachex/actions/clear_test.exs
@@ -9,7 +9,7 @@ defmodule Cachex.Actions.ClearTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # fill with some items
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -17,7 +17,7 @@ defmodule Cachex.Actions.ClearTest do
     {:ok, true} = Cachex.put(cache, 3, 3)
 
     # clear all hook
-    Helper.flush()
+    TestUtils.flush()
 
     # clear the cache
     result = Cachex.clear(cache)
@@ -50,7 +50,7 @@ defmodule Cachex.Actions.ClearTest do
   @tag distributed: true
   test "clearing a cache cluster of all items" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/count_test.exs
+++ b/test/cachex/actions/count_test.exs
@@ -8,7 +8,7 @@ defmodule Cachex.Actions.CountTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # fill with some items
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -24,7 +24,7 @@ defmodule Cachex.Actions.CountTest do
     :timer.sleep(2)
 
     # clear all hook
-    Helper.flush()
+    TestUtils.flush()
 
     # count the cache
     result = Cachex.count(cache)
@@ -44,7 +44,7 @@ defmodule Cachex.Actions.CountTest do
   @tag distributed: true
   test "counting items in a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/count_test.exs
+++ b/test/cachex/actions/count_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.CountTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies that a cache can be successfully counted. Counting a cache
   # will return the size of the cache, but ignoring the number of expired entries.

--- a/test/cachex/actions/decr_test.exs
+++ b/test/cachex/actions/decr_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.DecrTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test covers various combinations of decrementing cache items, by tweaking
   # the options provided alongside the calls. We validate the flags and values

--- a/test/cachex/actions/decr_test.exs
+++ b/test/cachex/actions/decr_test.exs
@@ -9,7 +9,7 @@ defmodule Cachex.Actions.DecrTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # define write options
     opts1 = [initial: 10]
@@ -47,7 +47,7 @@ defmodule Cachex.Actions.DecrTest do
   # error flag in this case.
   test "decrementing a non-numeric value" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # set a non-numeric value
     {:ok, true} = Cachex.put(cache, "key", "value")
@@ -65,7 +65,7 @@ defmodule Cachex.Actions.DecrTest do
   @tag distributed: true
   test "decrementing items in a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, -1} = Cachex.decr(cache, 1, 1)

--- a/test/cachex/actions/del_test.exs
+++ b/test/cachex/actions/del_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.DelTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This case tests that we can safely remove items from the cache. We test the
   # removal of both existing and missing keys, as the behaviour is the same for

--- a/test/cachex/actions/del_test.exs
+++ b/test/cachex/actions/del_test.exs
@@ -9,7 +9,7 @@ defmodule Cachex.Actions.DelTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # add some cache entries
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -41,7 +41,7 @@ defmodule Cachex.Actions.DelTest do
   @tag distributed: true
   test "removing entries from a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/dump_test.exs
+++ b/test/cachex/actions/dump_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.DumpTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test covers the backing up of a cache to a local disk location. We only
   # cover the happy path as there are separate tests covering issues with the

--- a/test/cachex/actions/dump_test.exs
+++ b/test/cachex/actions/dump_test.exs
@@ -10,13 +10,13 @@ defmodule Cachex.Actions.DumpTest do
     tmp = System.tmp_dir!()
 
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # add some cache entries
     {:ok, true} = Cachex.put(cache, 1, 1)
 
     # create a local path to write to
-    path = Path.join(tmp, Helper.gen_rand_bytes(8))
+    path = Path.join(tmp, TestUtils.gen_rand_bytes(8))
 
     # dump the cache to a local file
     result1 = Cachex.dump(cache, path)
@@ -46,15 +46,15 @@ defmodule Cachex.Actions.DumpTest do
     tmp = System.tmp_dir!()
 
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)
     {:ok, true} = Cachex.put(cache, 2, 2)
 
     # create a local path to write to
-    path1 = Path.join(tmp, Helper.gen_rand_bytes(8))
-    path2 = Path.join(tmp, Helper.gen_rand_bytes(8))
+    path1 = Path.join(tmp, TestUtils.gen_rand_bytes(8))
+    path2 = Path.join(tmp, TestUtils.gen_rand_bytes(8))
 
     # dump the cache to a local file for local/remote
     dump1 = Cachex.dump(cache, path1, local: true)

--- a/test/cachex/actions/empty_test.exs
+++ b/test/cachex/actions/empty_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.EmptyTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies that a cache is empty. We first check that it is before
   # adding any items, and after we add some we check that it's no longer empty.

--- a/test/cachex/actions/empty_test.exs
+++ b/test/cachex/actions/empty_test.exs
@@ -10,7 +10,7 @@ defmodule Cachex.Actions.EmptyTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # check if the cache is empty
     result1 = Cachex.empty?(cache)
@@ -42,7 +42,7 @@ defmodule Cachex.Actions.EmptyTest do
   @tag distributed: true
   test "checking if a cache cluster is empty" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/execute_test.exs
+++ b/test/cachex/actions/execute_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.ExecuteTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test just makes sure that execution blocks are handled correctly in that
   # they can carry out many actions and return a joint result without having to

--- a/test/cachex/actions/execute_test.exs
+++ b/test/cachex/actions/execute_test.exs
@@ -6,7 +6,7 @@ defmodule Cachex.Actions.ExecuteTest do
   # go back to the cache table.
   test "execution blocks can carry out many actions" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # start an execution block
     result =

--- a/test/cachex/actions/exists_test.exs
+++ b/test/cachex/actions/exists_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.ExistsTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies whether a key exists in a cache. If it does, we return
   # true. If not we return false. If the key has expired, we return false and

--- a/test/cachex/actions/exists_test.exs
+++ b/test/cachex/actions/exists_test.exs
@@ -9,7 +9,7 @@ defmodule Cachex.Actions.ExistsTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # add some keys to the cache
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -19,7 +19,7 @@ defmodule Cachex.Actions.ExistsTest do
     :timer.sleep(2)
 
     # clear messages
-    Helper.flush()
+    TestUtils.flush()
 
     # check if several keys exist
     exists1 = Cachex.exists?(cache, 1)
@@ -58,7 +58,7 @@ defmodule Cachex.Actions.ExistsTest do
   @tag distributed: true
   test "checking if a key exists in a cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/expire_at_test.exs
+++ b/test/cachex/actions/expire_at_test.exs
@@ -10,7 +10,7 @@ defmodule Cachex.Actions.ExpireAtTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # add some keys to the cache
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -18,7 +18,7 @@ defmodule Cachex.Actions.ExpireAtTest do
     {:ok, true} = Cachex.put(cache, 3, 3, ttl: 10)
 
     # clear messages
-    Helper.flush()
+    TestUtils.flush()
 
     # grab current time
     ctime = now()
@@ -73,7 +73,7 @@ defmodule Cachex.Actions.ExpireAtTest do
   @tag distributed: true
   test "setting a key to expire at a given time in a cluster" do
     # create a new cache cluster
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/expire_at_test.exs
+++ b/test/cachex/actions/expire_at_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.ExpireAtTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test updates the expire time on a key to expire at a given timestamp.
   # We make sure that TTLs are updated accordingly. If a date in the past is

--- a/test/cachex/actions/expire_test.exs
+++ b/test/cachex/actions/expire_test.exs
@@ -10,7 +10,7 @@ defmodule Cachex.Actions.ExpireTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # add some keys to the cache
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -18,7 +18,7 @@ defmodule Cachex.Actions.ExpireTest do
     {:ok, true} = Cachex.put(cache, 3, 3, ttl: 10)
 
     # clear messages
-    Helper.flush()
+    TestUtils.flush()
 
     # set the expire time
     f_expire_time = 10000
@@ -70,7 +70,7 @@ defmodule Cachex.Actions.ExpireTest do
   @tag distributed: true
   test "setting a key to expire after a given period in a cluster" do
     # create a new cache cluster
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/expire_test.exs
+++ b/test/cachex/actions/expire_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.ExpireTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test updates the expire time on a key to expire after a given period.
   # We make sure that TTLs are updated accordingly. If the period is negative,

--- a/test/cachex/actions/export_test.exs
+++ b/test/cachex/actions/export_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.ExportTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies that it's possible to export the entries from a cache.
   # As it stands, this is a barebones test to ensure the length of the export

--- a/test/cachex/actions/export_test.exs
+++ b/test/cachex/actions/export_test.exs
@@ -6,7 +6,7 @@ defmodule Cachex.Actions.ExportTest do
   # as it's covered more heavily by the test cases based on `dump/3`.
   test "exporting records from a cache" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # fill with some items
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -28,7 +28,7 @@ defmodule Cachex.Actions.ExportTest do
   @tag distributed: true
   test "exporting records from a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/fetch_test.exs
+++ b/test/cachex/actions/fetch_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.FetchTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies that we can retrieve keys from the cache with the
   # ability to compute values if they're missing. If a key has expired,

--- a/test/cachex/actions/fetch_test.exs
+++ b/test/cachex/actions/fetch_test.exs
@@ -13,10 +13,10 @@ defmodule Cachex.Actions.FetchTest do
     concat = &(&1 <> "_" <> &2)
 
     # create a test cache
-    cache1 = Helper.create_cache(hooks: [hook])
+    cache1 = TestUtils.create_cache(hooks: [hook])
 
     cache2 =
-      Helper.create_cache(
+      TestUtils.create_cache(
         hooks: [hook],
         fallback: fallback(state: "val", default: concat)
       )
@@ -29,7 +29,7 @@ defmodule Cachex.Actions.FetchTest do
     :timer.sleep(2)
 
     # flush all existing messages
-    Helper.flush()
+    TestUtils.flush()
 
     # define the fallback options
     fb_opt1 = &String.reverse/1
@@ -103,7 +103,7 @@ defmodule Cachex.Actions.FetchTest do
   test "fetching and committing the same key simultaneously from a fallback" do
     for _ <- 1..10 do
       # create a test cache
-      cache = Helper.create_cache()
+      cache = TestUtils.create_cache()
 
       # basic fallback
       fallback1 = fn ->
@@ -140,7 +140,7 @@ defmodule Cachex.Actions.FetchTest do
 
   test "fetching and setting an expiration on a key from a fallback" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # create a fallback with an expiration
     purged = [ttl: 60000]
@@ -165,7 +165,7 @@ defmodule Cachex.Actions.FetchTest do
   @tag distributed: true
   test "fetching keys from a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes - have to make sure that we
     # use a known function, otherwise it fails with an undefined function.
@@ -186,7 +186,7 @@ defmodule Cachex.Actions.FetchTest do
   # bug were to reappear, this test should fail and catch it.
   test "fetching will only call fallback once per key" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # create a test agent to hold our test state
     {:ok, agent} = Agent.start_link(fn -> %{} end)

--- a/test/cachex/actions/get_and_update_test.exs
+++ b/test/cachex/actions/get_and_update_test.exs
@@ -9,7 +9,7 @@ defmodule Cachex.Actions.GetAndUpdateTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # set some keys in the cache
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -22,7 +22,7 @@ defmodule Cachex.Actions.GetAndUpdateTest do
     :timer.sleep(25)
 
     # flush all existing messages
-    Helper.flush()
+    TestUtils.flush()
 
     # update the first and second keys
     result1 = Cachex.get_and_update(cache, 1, &to_string/1)
@@ -102,7 +102,7 @@ defmodule Cachex.Actions.GetAndUpdateTest do
   @tag distributed: true
   test "retrieving and updated cache records in a cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/get_and_update_test.exs
+++ b/test/cachex/actions/get_and_update_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.GetAndUpdateTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies that we can retrieve and update cache values. We make sure
   # to check the ability to ignore a value rather than committing, as well as the

--- a/test/cachex/actions/get_test.exs
+++ b/test/cachex/actions/get_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.GetTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies that we can retrieve keys from the cache.
   # If a key has expired, the value is not returned and the hooks

--- a/test/cachex/actions/get_test.exs
+++ b/test/cachex/actions/get_test.exs
@@ -10,7 +10,7 @@ defmodule Cachex.Actions.GetTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache1 = Helper.create_cache(hooks: [hook])
+    cache1 = TestUtils.create_cache(hooks: [hook])
 
     # set some keys in the cache
     {:ok, true} = Cachex.put(cache1, 1, 1)
@@ -20,7 +20,7 @@ defmodule Cachex.Actions.GetTest do
     :timer.sleep(2)
 
     # flush all existing messages
-    Helper.flush()
+    TestUtils.flush()
 
     # take the first and second key
     result1 = Cachex.get(cache1, 1)
@@ -51,7 +51,7 @@ defmodule Cachex.Actions.GetTest do
   @tag distributed: true
   test "retrieving keys from a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/import_test.exs
+++ b/test/cachex/actions/import_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.ImportTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies that it's possible to import entries into a cache.
   # As it stands, this is a barebones test to ensure the length of the

--- a/test/cachex/actions/import_test.exs
+++ b/test/cachex/actions/import_test.exs
@@ -6,7 +6,7 @@ defmodule Cachex.Actions.ImportTest do
   # import as it's covered more heavily by the test cases based on `load/2`.
   test "importing records into a cache" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
     start = now()
 
     # add some cache entries

--- a/test/cachex/actions/incr_test.exs
+++ b/test/cachex/actions/incr_test.exs
@@ -9,7 +9,7 @@ defmodule Cachex.Actions.IncrTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # define write options
     opts1 = [initial: 10]
@@ -47,7 +47,7 @@ defmodule Cachex.Actions.IncrTest do
   # error flag in this case.
   test "incrementing a non-numeric value" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # set a non-numeric value
     {:ok, true} = Cachex.put(cache, "key", "value")
@@ -65,7 +65,7 @@ defmodule Cachex.Actions.IncrTest do
   @tag distributed: true
   test "incrementing items in a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, 1} = Cachex.incr(cache, 1, 1)

--- a/test/cachex/actions/incr_test.exs
+++ b/test/cachex/actions/incr_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.IncrTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test covers various combinations of incrementing cache items, by tweaking
   # the options provided alongside the calls. We validate the flags and values

--- a/test/cachex/actions/inspect_test.exs
+++ b/test/cachex/actions/inspect_test.exs
@@ -6,7 +6,7 @@ defmodule Cachex.Actions.InspectTest do
   # count of expired keys, as well as retrieving a list of expired keys.
   test "inspecting expired keys" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # set several values in the cache
     for x <- 1..3 do
@@ -45,8 +45,8 @@ defmodule Cachex.Actions.InspectTest do
   # error is returned if there is no Janitor process started for the cache.
   test "inspecting janitor metadata" do
     # create a cache with no janitor and one with
-    cache1 = Helper.create_cache(expiration: expiration(interval: nil))
-    cache2 = Helper.create_cache(expiration: expiration(interval: 1))
+    cache1 = TestUtils.create_cache(expiration: expiration(interval: nil))
+    cache2 = TestUtils.create_cache(expiration: expiration(interval: 1))
 
     # let the janitor run
     :timer.sleep(2)
@@ -72,7 +72,7 @@ defmodule Cachex.Actions.InspectTest do
   # as either a binary or a number of bytes.
   test "inspecting cache memory" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # retrieve the memory usage
     {:ok, result1} = Cachex.inspect(cache, {:memory, :bytes})
@@ -100,7 +100,7 @@ defmodule Cachex.Actions.InspectTest do
   # nil, and that an existing record returns the record.
   test "inspecting cache records" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # get the current time
     ctime = now()
@@ -130,7 +130,7 @@ defmodule Cachex.Actions.InspectTest do
   # than using the state passed in. This is the only thing to verify.
   test "inspecting cache state" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # retrieve the cache state
     state1 = Services.Overseer.retrieve(cache)
@@ -155,7 +155,7 @@ defmodule Cachex.Actions.InspectTest do
   # is unrecognised. There's nothing else to validate beyond the error.
   test "inspecting invalid options" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # retrieve an invalid option
     result = Cachex.inspect(cache, :invalid)
@@ -170,7 +170,7 @@ defmodule Cachex.Actions.InspectTest do
   @tag distributed: true
   test "inspections always run on the local node" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/inspect_test.exs
+++ b/test/cachex/actions/inspect_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.InspectTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test ensures that we can correctly inspect various things related to
   # expired keys inside the cache. We need to make sure that the check both the

--- a/test/cachex/actions/invoke_test.exs
+++ b/test/cachex/actions/invoke_test.exs
@@ -9,7 +9,7 @@ defmodule Cachex.Actions.InvokeTest do
   test "invoking :write commands" do
     # create a test cache
     cache =
-      Helper.create_cache(
+      TestUtils.create_cache(
         commands: [
           lpop: command(type: :write, execute: &lpop/1),
           rpop: command(type: :write, execute: &rpop/1)
@@ -56,7 +56,7 @@ defmodule Cachex.Actions.InvokeTest do
   test "invoking :read commands" do
     # create a test cache
     cache =
-      Helper.create_cache(
+      TestUtils.create_cache(
         commands: [
           last: command(type: :read, execute: &List.last/1)
         ]
@@ -87,7 +87,7 @@ defmodule Cachex.Actions.InvokeTest do
   # fail, as well as commands which have been badly formed due to arity or tag.
   test "invoking invalid commands" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # retrieve the state
     state = Services.Overseer.retrieve(cache)
@@ -121,7 +121,7 @@ defmodule Cachex.Actions.InvokeTest do
   test "invoking commands in a cache cluster" do
     # create a new cache cluster for cleaning
     {cache, _nodes} =
-      Helper.create_cache_cluster(2,
+      TestUtils.create_cache_cluster(2,
         commands: [
           last: command(type: :read, execute: &List.last/1)
         ]

--- a/test/cachex/actions/invoke_test.exs
+++ b/test/cachex/actions/invoke_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.InvokeTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test covers the ability to run commands tagged with the `:modify` type.
   # We test that we can return our own values whilst modifying Lists. There is

--- a/test/cachex/actions/keys_test.exs
+++ b/test/cachex/actions/keys_test.exs
@@ -10,7 +10,7 @@ defmodule Cachex.Actions.KeysTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # fill with some items
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -26,7 +26,7 @@ defmodule Cachex.Actions.KeysTest do
     :timer.sleep(2)
 
     # clear all hook
-    Helper.flush()
+    TestUtils.flush()
 
     # retrieve the keys
     {status, keys} = Cachex.keys(cache)
@@ -52,7 +52,7 @@ defmodule Cachex.Actions.KeysTest do
   @tag distributed: true
   test "checking if a cache cluster is empty" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/keys_test.exs
+++ b/test/cachex/actions/keys_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.KeysTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies that it's possible to retrieve the keys inside a cache.
   # It should be noted that the keys function takes TTL into account and only

--- a/test/cachex/actions/load_test.exs
+++ b/test/cachex/actions/load_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.LoadTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test covers the backing up of a cache to a local disk location. We set
   # a value, dump to disk, then clear the cache. We then load the backup file to

--- a/test/cachex/actions/load_test.exs
+++ b/test/cachex/actions/load_test.exs
@@ -10,7 +10,7 @@ defmodule Cachex.Actions.LoadTest do
     tmp = System.tmp_dir!()
 
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
     start = now()
 
     # add some cache entries
@@ -19,7 +19,7 @@ defmodule Cachex.Actions.LoadTest do
     {:ok, true} = Cachex.put(cache, 3, 3, ttl: 10_000)
 
     # create a local path to write to
-    path = Path.join(tmp, Helper.gen_rand_bytes(8))
+    path = Path.join(tmp, TestUtils.gen_rand_bytes(8))
 
     # dump the cache to a local file
     result1 = Cachex.dump(cache, path)

--- a/test/cachex/actions/persist_test.exs
+++ b/test/cachex/actions/persist_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.PersistTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test just ensures that we can safely remove expiration times from a key.
   # We set a TTL on a key and then persist it and verify that there is then no

--- a/test/cachex/actions/persist_test.exs
+++ b/test/cachex/actions/persist_test.exs
@@ -9,14 +9,14 @@ defmodule Cachex.Actions.PersistTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # add some keys to the cache
     {:ok, true} = Cachex.put(cache, 1, 1)
     {:ok, true} = Cachex.put(cache, 2, 2, ttl: 1000)
 
     # clear messages
-    Helper.flush()
+    TestUtils.flush()
 
     # retrieve all TTLs from the cache
     ttl1 = Cachex.ttl!(cache, 1)
@@ -60,7 +60,7 @@ defmodule Cachex.Actions.PersistTest do
   @tag distributed: true
   test "removing the TTL on a key in a cluster" do
     # create a new cache cluster
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1, ttl: 5000)

--- a/test/cachex/actions/purge_test.exs
+++ b/test/cachex/actions/purge_test.exs
@@ -10,13 +10,13 @@ defmodule Cachex.Actions.PurgeTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # add a new cache entry
     {:ok, true} = Cachex.put(cache, "key", "value", ttl: 25)
 
     # flush messages
-    Helper.flush()
+    TestUtils.flush()
 
     # purge before the entry expires
     purge1 = Cachex.purge(cache)
@@ -54,7 +54,7 @@ defmodule Cachex.Actions.PurgeTest do
   @tag distributed: true
   test "purging expired records in a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1, ttl: 1)

--- a/test/cachex/actions/purge_test.exs
+++ b/test/cachex/actions/purge_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.PurgeTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test makes sure that we can manually purge expired records from the cache.
   # We attempt to purge before a key has expired and verify that it has not been

--- a/test/cachex/actions/put_many_test.exs
+++ b/test/cachex/actions/put_many_test.exs
@@ -10,11 +10,11 @@ defmodule Cachex.Actions.PutManyTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache1 = Helper.create_cache(hooks: [hook])
+    cache1 = TestUtils.create_cache(hooks: [hook])
 
     # create a test cache with a default ttl
     cache2 =
-      Helper.create_cache(hooks: [hook], expiration: expiration(default: 10000))
+      TestUtils.create_cache(hooks: [hook], expiration: expiration(default: 10000))
 
     # set some values in the cache
     set1 = Cachex.put_many(cache1, [{1, 1}, {2, 2}])
@@ -85,7 +85,7 @@ defmodule Cachex.Actions.PutManyTest do
   # short circuiting in order to speed up the empty batch.
   test "handling empty pairs in a batch" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # try set some values in the cache
     result = Cachex.put_many(cache, [])
@@ -102,7 +102,7 @@ defmodule Cachex.Actions.PutManyTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # try set some values in the cache
     set1 = Cachex.put_many(cache, [{1, 1}, "key"])
@@ -124,7 +124,7 @@ defmodule Cachex.Actions.PutManyTest do
   @tag distributed: true
   test "adding new entries to a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 2 & 3 hash to the same slots
     {:ok, true} = Cachex.put_many(cache, [{2, 2}, {3, 3}])
@@ -143,7 +143,7 @@ defmodule Cachex.Actions.PutManyTest do
   @tag distributed: true
   test "multiple slots will return a :cross_slot error" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 3 don't hash to the same slots
     put_many = Cachex.put_many(cache, [{1, 1}, {3, 3}])

--- a/test/cachex/actions/put_many_test.exs
+++ b/test/cachex/actions/put_many_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.PutManyTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies the addition of many new entries to a cache. It will
   # ensure that values can be added and can be expired as necessary. These

--- a/test/cachex/actions/put_test.exs
+++ b/test/cachex/actions/put_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.PutTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies the addition of new entries to the cache. We ensure that
   # values can be added and can be given expiration values. We also test the case

--- a/test/cachex/actions/put_test.exs
+++ b/test/cachex/actions/put_test.exs
@@ -10,11 +10,11 @@ defmodule Cachex.Actions.PutTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache1 = Helper.create_cache(hooks: [hook])
+    cache1 = TestUtils.create_cache(hooks: [hook])
 
     # create a test cache with a default ttl
     cache2 =
-      Helper.create_cache(hooks: [hook], expiration: expiration(default: 10000))
+      TestUtils.create_cache(hooks: [hook], expiration: expiration(default: 10000))
 
     # set some values in the cache
     set1 = Cachex.put(cache1, 1, 1)
@@ -71,7 +71,7 @@ defmodule Cachex.Actions.PutTest do
   @tag distributed: true
   test "adding new entries to a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/refresh_test.exs
+++ b/test/cachex/actions/refresh_test.exs
@@ -10,14 +10,14 @@ defmodule Cachex.Actions.RefreshTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # add some keys to the cache
     {:ok, true} = Cachex.put(cache, 1, 1)
     {:ok, true} = Cachex.put(cache, 2, 2, ttl: 1000)
 
     # clear messages
-    Helper.flush()
+    TestUtils.flush()
 
     # wait for 25ms
     :timer.sleep(25)
@@ -66,7 +66,7 @@ defmodule Cachex.Actions.RefreshTest do
   @tag distributed: true
   test "refreshing the TTL on a key in a cluster" do
     # create a new cache cluster
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1, ttl: 500)

--- a/test/cachex/actions/refresh_test.exs
+++ b/test/cachex/actions/refresh_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.RefreshTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies that we can reset the TTL time on a key. We check this
   # by settings keys with and without a TTL, waiting for some time to pass, and

--- a/test/cachex/actions/reset_test.exs
+++ b/test/cachex/actions/reset_test.exs
@@ -11,10 +11,10 @@ defmodule Cachex.Actions.ResetTest do
   # coverage tools, as the entire point is that it doesn't do anything.
   test "resetting a cache" do
     # create a test cache
-    cache1 = Helper.create_cache(stats: true)
+    cache1 = TestUtils.create_cache(stats: true)
 
     # create a cache with no hooks
-    cache2 = Helper.create_cache()
+    cache2 = TestUtils.create_cache()
 
     # get current time
     ctime1 = now()
@@ -64,7 +64,7 @@ defmodule Cachex.Actions.ResetTest do
   # to verify that the cache is empty after the reset.
   test "resetting only a cache" do
     # create a test cache
-    cache = Helper.create_cache(stats: true)
+    cache = TestUtils.create_cache(stats: true)
 
     # get current time
     ctime1 = now()
@@ -105,7 +105,7 @@ defmodule Cachex.Actions.ResetTest do
   # that the creation_date of the stats hook is reset properly.
   test "resetting only a cache's hooks" do
     # create a test cache
-    cache = Helper.create_cache(stats: true)
+    cache = TestUtils.create_cache(stats: true)
 
     # get current time
     ctime1 = now()
@@ -167,7 +167,7 @@ defmodule Cachex.Actions.ResetTest do
   @tag distributed: true
   test "resetting a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/reset_test.exs
+++ b/test/cachex/actions/reset_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.ResetTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test ensures that we can reset a cache completely, resetting the state
   # of all hooks and emptying the cache of keys. We verify this using the stats

--- a/test/cachex/actions/size_test.exs
+++ b/test/cachex/actions/size_test.exs
@@ -10,7 +10,7 @@ defmodule Cachex.Actions.SizeTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # retrieve the cache size
     result1 = Cachex.size(cache)
@@ -57,7 +57,7 @@ defmodule Cachex.Actions.SizeTest do
   @tag distributed: true
   test "checking the total size of a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/size_test.exs
+++ b/test/cachex/actions/size_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.SizeTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies the size of a cache. It should be noted that size is the
   # total size of the cache, regardless of any evictions (unlike count). We make

--- a/test/cachex/actions/stats_test.exs
+++ b/test/cachex/actions/stats_test.exs
@@ -6,7 +6,7 @@ defmodule Cachex.Actions.StatsTest do
   # filtered by the provided flags in order to customize output correctly.
   test "retrieving stats for a cache" do
     # create a test cache
-    cache = Helper.create_cache(stats: true)
+    cache = TestUtils.create_cache(stats: true)
 
     # retrieve current time
     ctime = now()
@@ -35,7 +35,7 @@ defmodule Cachex.Actions.StatsTest do
   # when they have already been disabled.
   test "retrieving stats from a disabled cache" do
     # create a test cache
-    cache = Helper.create_cache(stats: false)
+    cache = TestUtils.create_cache(stats: false)
 
     # retrieve default stats
     stats = Cachex.stats(cache)
@@ -49,10 +49,10 @@ defmodule Cachex.Actions.StatsTest do
   # 50% either way.
   test "retrieving different rate combinations" do
     # create test caches
-    cache1 = Helper.create_cache(stats: true)
-    cache2 = Helper.create_cache(stats: true)
-    cache3 = Helper.create_cache(stats: true)
-    cache4 = Helper.create_cache(stats: true)
+    cache1 = TestUtils.create_cache(stats: true)
+    cache2 = TestUtils.create_cache(stats: true)
+    cache3 = TestUtils.create_cache(stats: true)
+    cache4 = TestUtils.create_cache(stats: true)
 
     # set cache1 to 100% misses
     {:ok, nil} = Cachex.get(cache1, 1)
@@ -152,7 +152,7 @@ defmodule Cachex.Actions.StatsTest do
   @tag distributed: true
   test "retrieving stats for a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2, stats: true)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2, stats: true)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/stats_test.exs
+++ b/test/cachex/actions/stats_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.StatsTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test covers stats retrieval by making sure that the numbers coming back
   # are both accurate and concise. We verify that the payload returned can be

--- a/test/cachex/actions/stream_test.exs
+++ b/test/cachex/actions/stream_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.StreamTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test ensures that a default cache stream will stream cache entries
   # back in record form back to the calling process. This test just makes sure

--- a/test/cachex/actions/stream_test.exs
+++ b/test/cachex/actions/stream_test.exs
@@ -6,7 +6,7 @@ defmodule Cachex.Actions.StreamTest do
   # that the Stream correctly forms these Tuples using the default structure.
   test "streaming cache entries" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # add some keys to the cache
     {:ok, true} = Cachex.put(cache, "key1", "value1")
@@ -33,7 +33,7 @@ defmodule Cachex.Actions.StreamTest do
   # field in order to test this properly.
   test "streaming custom patterns" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # add some keys to the cache
     {:ok, true} = Cachex.put(cache, "key1", "value1")
@@ -69,7 +69,7 @@ defmodule Cachex.Actions.StreamTest do
   # We just ensure that this breaks accordingly and returns an invalid match error.
   test "streaming invalid patterns" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # create cache stream
     result = Cachex.stream(cache, {:invalid})
@@ -83,7 +83,7 @@ defmodule Cachex.Actions.StreamTest do
   @tag distributed: true
   test "streaming is disabled in a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we shouldn't be able to stream a cache on multiple nodes
     assert(Cachex.stream(cache) == {:error, :non_distributed})

--- a/test/cachex/actions/take_test.exs
+++ b/test/cachex/actions/take_test.exs
@@ -9,7 +9,7 @@ defmodule Cachex.Actions.TakeTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # set some keys in the cache
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -19,7 +19,7 @@ defmodule Cachex.Actions.TakeTest do
     :timer.sleep(2)
 
     # flush all existing messages
-    Helper.flush()
+    TestUtils.flush()
 
     # take the first and second key
     result1 = Cachex.take(cache, 1)
@@ -60,7 +60,7 @@ defmodule Cachex.Actions.TakeTest do
   @tag distributed: true
   test "taking entries from a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/take_test.exs
+++ b/test/cachex/actions/take_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.TakeTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies that we can take keys from the cache. If a key has expired,
   # the value is not returned and the hooks are updated with an eviction. If the

--- a/test/cachex/actions/touch_test.exs
+++ b/test/cachex/actions/touch_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.TouchTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test ensures that we can safely update the touch time of a key without
   # affecting when the key will be removed. We verify the TTL before and after

--- a/test/cachex/actions/touch_test.exs
+++ b/test/cachex/actions/touch_test.exs
@@ -10,7 +10,7 @@ defmodule Cachex.Actions.TouchTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # pull back the state
     state = Services.Overseer.retrieve(cache)
@@ -20,7 +20,7 @@ defmodule Cachex.Actions.TouchTest do
     {:ok, true} = Cachex.put(cache, 2, 2, ttl: 1000)
 
     # clear messages
-    Helper.flush()
+    TestUtils.flush()
 
     # retrieve the raw records
     entry(touched: touched1, ttl: ttl1) = Cachex.Actions.read(state, 1)
@@ -81,7 +81,7 @@ defmodule Cachex.Actions.TouchTest do
   @tag distributed: true
   test "adding new entries to a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1)

--- a/test/cachex/actions/transaction_test.exs
+++ b/test/cachex/actions/transaction_test.exs
@@ -10,7 +10,7 @@ defmodule Cachex.Actions.TransactionTest do
   # the value for the first time.
   test "executing a transaction is atomic" do
     # create a test cache
-    cache = Helper.create_cache(transactions: true)
+    cache = TestUtils.create_cache(transactions: true)
 
     # spawn a transaction to increment a key
     spawn(fn ->
@@ -34,7 +34,7 @@ defmodule Cachex.Actions.TransactionTest do
   # and an error status is returned instead of crashing the transaction server.
   test "raising errors from inside transactions" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # execute a broken transaction
     result1 =
@@ -61,7 +61,7 @@ defmodule Cachex.Actions.TransactionTest do
   # have transactions enabled from that point onwards.
   test "transactions become enabled automatically" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # retrieve the cache state
     state1 = Services.Overseer.retrieve(cache)
@@ -85,7 +85,7 @@ defmodule Cachex.Actions.TransactionTest do
   @tag distributed: true
   test "transactions inside a cache cluster" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 2 & 3 hash to the same slots
     {:ok, result} = Cachex.transaction(cache, [], &:erlang.phash2/1)
@@ -100,7 +100,7 @@ defmodule Cachex.Actions.TransactionTest do
   @tag distributed: true
   test "multiple slots will return a :cross_slot error" do
     # create a new cache cluster for cleaning
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 3 don't hash to the same slots
     transaction = Cachex.transaction(cache, [1, 2], &:erlang.phash2/1)

--- a/test/cachex/actions/transaction_test.exs
+++ b/test/cachex/actions/transaction_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.TransactionTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test ensures that a transaction will block any write operations on the
   # same keys by ensuring the the transaction has executed completely before any

--- a/test/cachex/actions/ttl_test.exs
+++ b/test/cachex/actions/ttl_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.TtlTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies the responses of checking TTLs inside the cache. We make
   # sure that TTLs are calculated correctly based on nil and set TTLs. If the

--- a/test/cachex/actions/ttl_test.exs
+++ b/test/cachex/actions/ttl_test.exs
@@ -6,7 +6,7 @@ defmodule Cachex.Actions.TtlTest do
   # key is missing, we return a tuple signalling such.
   test "retrieving a key TTL" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # set several keys in the cache
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -35,7 +35,7 @@ defmodule Cachex.Actions.TtlTest do
   @tag distributed: true
   test "retrieving a key TTL in a cluster" do
     # create a new cache cluster
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1, ttl: 500)

--- a/test/cachex/actions/update_test.exs
+++ b/test/cachex/actions/update_test.exs
@@ -7,7 +7,7 @@ defmodule Cachex.Actions.UpdateTest do
   # not overwritten).
   test "updates against an existing key" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # set a value with no TTL inside the cache
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -46,7 +46,7 @@ defmodule Cachex.Actions.UpdateTest do
   # update a value which does not exist inside the cache.
   test "updates against a missing key" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # attempt to update a missing key in the cache
     update1 = Cachex.update(cache, 1, 3)
@@ -63,7 +63,7 @@ defmodule Cachex.Actions.UpdateTest do
   @tag distributed: true
   test "updating a key in a cache cluster" do
     # create a new cache cluster
-    {cache, _nodes} = Helper.create_cache_cluster(2)
+    {cache, _nodes} = TestUtils.create_cache_cluster(2)
 
     # we know that 1 & 2 hash to different nodes
     {:ok, true} = Cachex.put(cache, 1, 1, ttl: 500)

--- a/test/cachex/actions/update_test.exs
+++ b/test/cachex/actions/update_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.UpdateTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test just ensures that we can update the value associated with a key
   # when the value already exists inside the cache. We make sure that any TTL

--- a/test/cachex/actions/warm_test.exs
+++ b/test/cachex/actions/warm_test.exs
@@ -5,13 +5,13 @@ defmodule Cachex.Actions.WarmTest do
   # after manually clearing it but checking again before the schedule.
   test "manually warming a cache" do
     # create a test warmer to pass to the cache
-    Helper.create_warmer(:manual_warmer1, :timer.hours(1), fn _ ->
+    TestUtils.create_warmer(:manual_warmer1, :timer.hours(1), fn _ ->
       {:ok, [{1, 1}]}
     end)
 
     # create a cache instance with a warmer
     cache =
-      Helper.create_cache(
+      TestUtils.create_cache(
         warmers: [
           warmer(
             module: :manual_warmer1,
@@ -39,13 +39,13 @@ defmodule Cachex.Actions.WarmTest do
 
   test "manually warming a cache and awaiting results" do
     # create a test warmer to pass to the cache
-    Helper.create_warmer(:manual_warmer2, :timer.hours(1), fn _ ->
+    TestUtils.create_warmer(:manual_warmer2, :timer.hours(1), fn _ ->
       {:ok, [{1, 1}]}
     end)
 
     # create a cache instance with a warmer
     cache =
-      Helper.create_cache(
+      TestUtils.create_cache(
         warmers: [
           warmer(
             module: :manual_warmer2,
@@ -71,13 +71,13 @@ defmodule Cachex.Actions.WarmTest do
   # provided list, and therefore no cache warming actually executes.
   test "manually warming a cache using specific warmers" do
     # create a test warmer to pass to the cache
-    Helper.create_warmer(:manual_warmer3, :timer.hours(1), fn _ ->
+    TestUtils.create_warmer(:manual_warmer3, :timer.hours(1), fn _ ->
       {:ok, [{1, 1}]}
     end)
 
     # create a cache instance with a warmer
     cache =
-      Helper.create_cache(
+      TestUtils.create_cache(
         warmers: [
           warmer(
             module: :manual_warmer3,

--- a/test/cachex/actions/warm_test.exs
+++ b/test/cachex/actions/warm_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Actions.WarmTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test covers the basic case of manually rewarming a cache,
   # after manually clearing it but checking again before the schedule.

--- a/test/cachex/actions_test.exs
+++ b/test/cachex/actions_test.exs
@@ -18,7 +18,7 @@ defmodule Cachex.ActionsTest do
     hook = ForwardHook.create()
 
     # create a test cache
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
 
     # retrieve the state
     state = Services.Overseer.retrieve(cache)
@@ -56,7 +56,7 @@ defmodule Cachex.ActionsTest do
 
   test "carrying out generic write actions" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # retrieve the state
     state = Services.Overseer.retrieve(cache)

--- a/test/cachex/actions_test.exs
+++ b/test/cachex/actions_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.ActionsTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   require Cachex.Actions
 

--- a/test/cachex/disk_test.exs
+++ b/test/cachex/disk_test.exs
@@ -20,7 +20,7 @@ defmodule Cachex.DiskTest do
     # define a validation function
     validate = fn options ->
       # generate a new path to write to
-      path = Path.join(tmp, Helper.gen_rand_bytes(8))
+      path = Path.join(tmp, TestUtils.gen_rand_bytes(8))
 
       # write our base value to the file
       result1 = Cachex.Disk.write(values, path, options)

--- a/test/cachex/disk_test.exs
+++ b/test/cachex/disk_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.DiskTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test just ensures that we can correctly write values to disk when using
   # varying levels of compression and that we can read back the exact same value

--- a/test/cachex/errors_test.exs
+++ b/test/cachex/errors_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.ErrorsTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test ensures the integrity of all Error functions and forms. We iterate
   # all errors and check that the long form of the error is as expected.

--- a/test/cachex/execution_error_test.exs
+++ b/test/cachex/execution_error_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.ExecutionErrorTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test just validates the default error message against an ExecutionError.
   # There is nothing more to validate beyond the returned message.

--- a/test/cachex/hook_test.exs
+++ b/test/cachex/hook_test.exs
@@ -1,3 +1,3 @@
 defmodule Cachex.HookTest do
-  use CachexCase
+  use Cachex.Test.Case
 end

--- a/test/cachex/options_test.exs
+++ b/test/cachex/options_test.exs
@@ -15,7 +15,7 @@ defmodule Cachex.OptionsTest do
   # will just ensure that this is done correctly.
   test "adding a cache name to the state" do
     # grab a cache name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # parse the options into a validated cache state
     assert match?({:ok, cache(name: ^name)}, Cachex.Options.parse(name, []))
@@ -67,7 +67,7 @@ defmodule Cachex.OptionsTest do
   # as a Map - so we need to make sure the kept command is intuitive for the user.
   test "parsing :commands flags" do
     # grab a cache name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # define some functions
     fun1 = fn _ -> [1, 2, 3] end
@@ -118,7 +118,7 @@ defmodule Cachex.OptionsTest do
   # is set to true or false, and the default.
   test "parsing :compressed flags" do
     # grab a cache name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # parse our values as options
     {:ok, cache(compressed: comp1)} =
@@ -139,7 +139,7 @@ defmodule Cachex.OptionsTest do
   # combinations of :ttl_interval and :default_ttl to verify each state correctly.
   test "parsing :expiration flags" do
     # grab a cache name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # parse out valid combinations
     {:ok, cache(expiration: exp1)} =
@@ -201,7 +201,7 @@ defmodule Cachex.OptionsTest do
   # the provided value is a valid function (of any arity).
   test "parsing :fallback flags" do
     # grab a cache name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # define our falbacks
     fallback1 = fallback()
@@ -251,7 +251,7 @@ defmodule Cachex.OptionsTest do
   # Hooks are grouped into the correct pre/post groups inside the state.
   test "parsing :hooks flags" do
     # grab a cache name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # create our pre hook
     pre_hook = ForwardHook.create(:options_pre_forward_hook)
@@ -289,7 +289,7 @@ defmodule Cachex.OptionsTest do
   # to also be verified within this test.
   test "parsing :limit flags" do
     # grab a cache name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # create a default limit
     default = limit()
@@ -329,7 +329,7 @@ defmodule Cachex.OptionsTest do
   # is set to true or false, and the default.
   test "parsing :ordered flags" do
     # grab a cache name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # parse our values as options
     {:ok, cache(ordered: ordered1)} =
@@ -349,7 +349,7 @@ defmodule Cachex.OptionsTest do
   # can be provided as either an atom module name, or a router struct.
   test "parsing :router flags" do
     # grab a cache name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # parse out valid router combinations
     {:ok, cache(router: router1)} = Cachex.Options.parse(name, [])
@@ -376,7 +376,7 @@ defmodule Cachex.OptionsTest do
   # We just need to verify that the hook is added after being parsed.
   test "parsing :stats flags" do
     # grab a cache name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # create a stats hook
     hook =
@@ -398,7 +398,7 @@ defmodule Cachex.OptionsTest do
   # locksmith has its name set inside the returned state.
   test "parsing :transactions flags" do
     # grab a cache name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # parse our values as options
     {:ok, cache(transactions: trans1)} =
@@ -417,10 +417,10 @@ defmodule Cachex.OptionsTest do
 
   test "parsing :warmers flags" do
     # grab a cache name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # define our warmer to pass through to the cache
-    Helper.create_warmer(:options_test_warmer, 50, fn _ ->
+    TestUtils.create_warmer(:options_test_warmer, 50, fn _ ->
       :ignore
     end)
 

--- a/test/cachex/options_test.exs
+++ b/test/cachex/options_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.OptionsTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # Bind any required hooks for test execution
   setup_all do

--- a/test/cachex/policy/lrw/evented_test.exs
+++ b/test/cachex/policy/lrw/evented_test.exs
@@ -6,7 +6,7 @@ defmodule Cachex.Policy.LRW.EventedTest do
   # validation that there are no bad defaults set anywhere.
   test "evicting with no upper bound" do
     # create a cache with no max size
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # retrieve the cache state
     state = Services.Overseer.retrieve(cache)
@@ -42,7 +42,7 @@ defmodule Cachex.Policy.LRW.EventedTest do
       )
 
     # create a cache with a max size
-    cache = Helper.create_cache(hooks: [hook], limit: limit)
+    cache = TestUtils.create_cache(hooks: [hook], limit: limit)
 
     # retrieve the cache state
     state = Services.Overseer.retrieve(cache)
@@ -63,7 +63,7 @@ defmodule Cachex.Policy.LRW.EventedTest do
     assert(size1 == 100)
 
     # flush all existing hook events
-    Helper.flush()
+    TestUtils.flush()
 
     # run a no-op fetch to verify no change
     {:ignore, nil} =
@@ -81,7 +81,7 @@ defmodule Cachex.Policy.LRW.EventedTest do
     {:ok, true} = Cachex.put(state, 101, 101)
 
     # verify the cache shrinks to 25%
-    Helper.poll(250, 25, fn ->
+    TestUtils.poll(250, 25, fn ->
       Cachex.size!(state)
     end)
 
@@ -130,7 +130,7 @@ defmodule Cachex.Policy.LRW.EventedTest do
       )
 
     # create a cache with a max size
-    cache = Helper.create_cache(limit: limit)
+    cache = TestUtils.create_cache(limit: limit)
 
     # retrieve the cache state
     state = Services.Overseer.retrieve(cache)
@@ -163,7 +163,7 @@ defmodule Cachex.Policy.LRW.EventedTest do
     {:ok, true} = Cachex.put(state, 101, 101)
 
     # verify the cache shrinks to 51%
-    Helper.poll(250, 51, fn ->
+    TestUtils.poll(250, 51, fn ->
       Cachex.size!(state)
     end)
 

--- a/test/cachex/policy/lrw/evented_test.exs
+++ b/test/cachex/policy/lrw/evented_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Policy.LRW.EventedTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test just ensures that there are no artificial limits placed on a cache
   # by adding 5000 keys and making sure they're not evicted. It simply serves as

--- a/test/cachex/policy/lrw/scheduled_test.exs
+++ b/test/cachex/policy/lrw/scheduled_test.exs
@@ -6,7 +6,7 @@ defmodule Cachex.Policy.LRW.ScheduledTest do
   # validation that there are no bad defaults set anywhere.
   test "evicting with no upper bound" do
     # create a cache with no max size
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # retrieve the cache state
     state = Services.Overseer.retrieve(cache)
@@ -42,7 +42,7 @@ defmodule Cachex.Policy.LRW.ScheduledTest do
       )
 
     # create a cache with a max size
-    cache = Helper.create_cache(hooks: [hook], limit: limit)
+    cache = TestUtils.create_cache(hooks: [hook], limit: limit)
 
     # retrieve the cache state
     state = Services.Overseer.retrieve(cache)
@@ -63,13 +63,13 @@ defmodule Cachex.Policy.LRW.ScheduledTest do
     assert(size1 == 100)
 
     # flush all existing hook events
-    Helper.flush()
+    TestUtils.flush()
 
     # add a new key to the cache to trigger evictions
     {:ok, true} = Cachex.put(state, 101, 101)
 
     # verify the cache shrinks to 25%
-    Helper.poll(250, 25, fn ->
+    TestUtils.poll(250, 25, fn ->
       Cachex.size!(state)
     end)
 
@@ -118,7 +118,7 @@ defmodule Cachex.Policy.LRW.ScheduledTest do
       )
 
     # create a cache with a max size
-    cache = Helper.create_cache(limit: limit)
+    cache = TestUtils.create_cache(limit: limit)
 
     # retrieve the cache state
     state = Services.Overseer.retrieve(cache)
@@ -151,7 +151,7 @@ defmodule Cachex.Policy.LRW.ScheduledTest do
     {:ok, true} = Cachex.put(state, 101, 101)
 
     # verify the cache shrinks to 51%
-    Helper.poll(250, 51, fn ->
+    TestUtils.poll(250, 51, fn ->
       Cachex.size!(state)
     end)
 

--- a/test/cachex/policy/lrw/scheduled_test.exs
+++ b/test/cachex/policy/lrw/scheduled_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Policy.LRW.ScheduledTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test just ensures that there are no artificial limits placed on a cache
   # by adding 5000 keys and making sure they're not evicted. It simply serves as

--- a/test/cachex/policy_test.exs
+++ b/test/cachex/policy_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.PolicyTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   test "default policy implementations" do
     assert __MODULE__.DefaultPolicy.hooks(limit()) == []

--- a/test/cachex/query_test.exs
+++ b/test/cachex/query_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.QueryTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # All queries are run through the basic query generation, so this test
   # will just validate the passing of query clauses through to the query

--- a/test/cachex/router/jump_test.exs
+++ b/test/cachex/router/jump_test.exs
@@ -4,7 +4,7 @@ defmodule Cachex.Router.JumpTest do
   test "routing keys via a jump router" do
     # create a test cache cluster for nodes
     {cache, nodes} =
-      Helper.create_cache_cluster(3,
+      TestUtils.create_cache_cluster(3,
         router: Cachex.Router.Jump
       )
 
@@ -33,7 +33,7 @@ defmodule Cachex.Router.JumpTest do
       )
 
     # create a test cache and fetch back
-    cache = Helper.create_cache(router: router)
+    cache = TestUtils.create_cache(router: router)
     cache = Services.Overseer.retrieve(cache)
 
     # fetch the router state after initialize

--- a/test/cachex/router/jump_test.exs
+++ b/test/cachex/router/jump_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Router.JumpTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   test "routing keys via a jump router" do
     # create a test cache cluster for nodes

--- a/test/cachex/router/local_test.exs
+++ b/test/cachex/router/local_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Router.LocalTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   test "routing keys via a local router" do
     # create a test cache

--- a/test/cachex/router/local_test.exs
+++ b/test/cachex/router/local_test.exs
@@ -3,7 +3,7 @@ defmodule Cachex.Router.LocalTest do
 
   test "routing keys via a local router" do
     # create a test cache
-    cache = Helper.create_cache(router: Cachex.Router.Local)
+    cache = TestUtils.create_cache(router: Cachex.Router.Local)
 
     # convert the name to a cache and sort
     cache = Services.Overseer.retrieve(cache)

--- a/test/cachex/router/mod_test.exs
+++ b/test/cachex/router/mod_test.exs
@@ -4,7 +4,7 @@ defmodule Cachex.Router.ModTest do
   test "routing keys via a modulo router" do
     # create a test cache cluster for nodes
     {cache, nodes} =
-      Helper.create_cache_cluster(3,
+      TestUtils.create_cache_cluster(3,
         router: Cachex.Router.Mod
       )
 
@@ -33,7 +33,7 @@ defmodule Cachex.Router.ModTest do
       )
 
     # create a test cache and fetch back
-    cache = Helper.create_cache(router: router)
+    cache = TestUtils.create_cache(router: router)
     cache = Services.Overseer.retrieve(cache)
 
     # fetch the router state after initialize

--- a/test/cachex/router/mod_test.exs
+++ b/test/cachex/router/mod_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Router.ModTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   test "routing keys via a modulo router" do
     # create a test cache cluster for nodes

--- a/test/cachex/router/ring_test.exs
+++ b/test/cachex/router/ring_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Router.RingTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   test "routing keys via a ring router" do
     # create a test cache cluster for nodes

--- a/test/cachex/router/ring_test.exs
+++ b/test/cachex/router/ring_test.exs
@@ -4,7 +4,7 @@ defmodule Cachex.Router.RingTest do
   test "routing keys via a ring router" do
     # create a test cache cluster for nodes
     {cache, _nodes} =
-      Helper.create_cache_cluster(3,
+      TestUtils.create_cache_cluster(3,
         router:
           router(
             module: Cachex.Router.Ring,
@@ -29,7 +29,7 @@ defmodule Cachex.Router.RingTest do
   test "routing keys via a ring router with monitored nodes" do
     # create a test cache cluster for nodes
     {cache, nodes} =
-      Helper.create_cache_cluster(3,
+      TestUtils.create_cache_cluster(3,
         router:
           router(
             module: Cachex.Router.Ring,

--- a/test/cachex/router_test.exs
+++ b/test/cachex/router_test.exs
@@ -1,3 +1,3 @@
 defmodule Cachex.RouterTest do
-  use CachexCase
+  use Cachex.Test.Case
 end

--- a/test/cachex/services/courier_test.exs
+++ b/test/cachex/services/courier_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Services.CourierTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   test "dispatching tasks" do
     # start a new cache

--- a/test/cachex/services/courier_test.exs
+++ b/test/cachex/services/courier_test.exs
@@ -3,7 +3,7 @@ defmodule Cachex.Services.CourierTest do
 
   test "dispatching tasks" do
     # start a new cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
     cache = Services.Overseer.retrieve(cache)
 
     # dispatch an arbitrary task
@@ -33,7 +33,7 @@ defmodule Cachex.Services.CourierTest do
     end
 
     # start a new cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
     cache = Services.Overseer.retrieve(cache)
     parent = self()
 
@@ -60,7 +60,7 @@ defmodule Cachex.Services.CourierTest do
 
   test "gracefully handling crashes inside tasks" do
     # start a new cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
     cache = Services.Overseer.retrieve(cache)
 
     # dispatch an arbitrary task
@@ -76,7 +76,7 @@ defmodule Cachex.Services.CourierTest do
 
   test "recovering from failed tasks" do
     # start a new cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
     cache = Services.Overseer.retrieve(cache)
 
     # kill in flight task

--- a/test/cachex/services/informant_test.exs
+++ b/test/cachex/services/informant_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Services.InformantTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # Bind any required hooks for test execution
   setup_all do

--- a/test/cachex/services/informant_test.exs
+++ b/test/cachex/services/informant_test.exs
@@ -29,9 +29,9 @@ defmodule Cachex.Services.InformantTest do
     hook3 = ForwardHook.create(:informant_forward_hook_actions_get)
 
     # start a cache with the hooks
-    cache1 = Helper.create_cache(hooks: [hook1])
-    cache2 = Helper.create_cache(hooks: [hook2])
-    cache3 = Helper.create_cache(hooks: [hook3])
+    cache1 = TestUtils.create_cache(hooks: [hook1])
+    cache2 = TestUtils.create_cache(hooks: [hook2])
+    cache3 = TestUtils.create_cache(hooks: [hook3])
 
     # grab a state instance for the broadcast
     state1 = Services.Overseer.retrieve(cache1)
@@ -82,10 +82,10 @@ defmodule Cachex.Services.InformantTest do
     hook5 = ForwardHook.create()
 
     # initialize caches to initialize the hooks
-    cache1 = Helper.create_cache(hooks: hook1)
-    cache2 = Helper.create_cache(hooks: hook2)
-    cache3 = Helper.create_cache(hooks: hook3)
-    cache4 = Helper.create_cache(hooks: hook4)
+    cache1 = TestUtils.create_cache(hooks: hook1)
+    cache2 = TestUtils.create_cache(hooks: hook2)
+    cache3 = TestUtils.create_cache(hooks: hook3)
+    cache4 = TestUtils.create_cache(hooks: hook4)
 
     # update our hooks from the caches
     cache(hooks: hooks(pre: [hook1])) = Services.Overseer.retrieve(cache1)

--- a/test/cachex/services/janitor_test.exs
+++ b/test/cachex/services/janitor_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Services.JanitorTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # We have a common utility to check whether a TTL has passed or not based on
   # an input of a write time and a TTL length. This test ensures that this returns

--- a/test/cachex/services/janitor_test.exs
+++ b/test/cachex/services/janitor_test.exs
@@ -58,7 +58,7 @@ defmodule Cachex.Services.JanitorTest do
 
     # create a test cache
     cache =
-      Helper.create_cache(
+      TestUtils.create_cache(
         hooks: hooks,
         expiration: expiration(interval: ttl_interval)
       )

--- a/test/cachex/services/locksmith_test.exs
+++ b/test/cachex/services/locksmith_test.exs
@@ -6,7 +6,7 @@ defmodule Cachex.Services.LocksmithTest do
   # and should be false when run outside of the Locksmith server, otherwise true.
   test "detecting a transactional context" do
     # start a new cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # fetch the cache state
     state = Services.Overseer.retrieve(cache)
@@ -31,8 +31,8 @@ defmodule Cachex.Services.LocksmithTest do
   # ensure that writes are queued unnecessarily.
   test "executing a write outside of a transaction" do
     # start two caches, one transactional, one not
-    cache1 = Helper.create_cache(transactions: true)
-    cache2 = Helper.create_cache(transactions: false)
+    cache1 = TestUtils.create_cache(transactions: true)
+    cache2 = TestUtils.create_cache(transactions: false)
 
     # fetch the states for the caches
     state1 = Services.Overseer.retrieve(cache1)
@@ -59,8 +59,8 @@ defmodule Cachex.Services.LocksmithTest do
   # itself, as it's needed to test the write execution.
   test "executing a transactional block" do
     # start two caches, one transactional, one not
-    cache1 = Helper.create_cache(transactions: false)
-    cache2 = Helper.create_cache(transactions: true)
+    cache1 = TestUtils.create_cache(transactions: false)
+    cache2 = TestUtils.create_cache(transactions: true)
 
     # fetch the states for the caches
     state1 = Services.Overseer.retrieve(cache1)
@@ -113,7 +113,7 @@ defmodule Cachex.Services.LocksmithTest do
   # notifies the user of the error occurring without causing other issues.
   test "executing a crashing transaction" do
     # create a test cache
-    cache = Helper.create_cache(transactions: true)
+    cache = TestUtils.create_cache(transactions: true)
 
     # retrieve the state for our cache
     state = Services.Overseer.retrieve(cache)
@@ -133,7 +133,7 @@ defmodule Cachex.Services.LocksmithTest do
   # being covered in case of race conditions on locks).
   test "locking items in a table" do
     # create a test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # retrieve the state for our cache
     state = Services.Overseer.retrieve(cache)

--- a/test/cachex/services/locksmith_test.exs
+++ b/test/cachex/services/locksmith_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Services.LocksmithTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test verifies that we can detect when we're running inside a transactional
   # context within a process. This is used to automatically detect nested transactions

--- a/test/cachex/services/overseer_test.exs
+++ b/test/cachex/services/overseer_test.exs
@@ -16,7 +16,7 @@ defmodule Cachex.OverseerTest do
   # We also cover removal just to avoid duplicating a lot of test code again.
   test "adding and removing state in the table" do
     # grab a state name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # create our state
     state = cache(name: name)
@@ -39,7 +39,7 @@ defmodule Cachex.OverseerTest do
   # we should get a nil.
   test "ensuring a state" do
     # grab a state name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # create our state
     state = cache(name: name)
@@ -63,7 +63,7 @@ defmodule Cachex.OverseerTest do
   # table in the first place.
   test "retrieving a state from the table" do
     # grab a state name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # create our state
     state = cache(name: name)
@@ -88,7 +88,7 @@ defmodule Cachex.OverseerTest do
     hook = ForwardHook.create(:overseer_forward_hook_provision)
 
     # start up our cache using the helper
-    name = Helper.create_cache(hooks: hook)
+    name = TestUtils.create_cache(hooks: hook)
 
     # retrieve our state
     cache(expiration: expiration) = state = Services.Overseer.retrieve(name)

--- a/test/cachex/services/overseer_test.exs
+++ b/test/cachex/services/overseer_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.OverseerTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # Bind any required hooks for test execution
   setup_all do

--- a/test/cachex/services/steward_test.exs
+++ b/test/cachex/services/steward_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Services.StewardTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   test "provisioning cache state" do
     # bind our hook

--- a/test/cachex/services/steward_test.exs
+++ b/test/cachex/services/steward_test.exs
@@ -13,7 +13,7 @@ defmodule Cachex.Services.StewardTest do
     hook = ForwardHook.create(:steward_forward_hook_provisions)
 
     # start a new cache using our forwarded hook
-    cache = Helper.create_cache(hooks: [hook])
+    cache = TestUtils.create_cache(hooks: [hook])
     cache = Services.Overseer.retrieve(cache)
 
     # the provisioned value should match

--- a/test/cachex/services_test.exs
+++ b/test/cachex/services_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.ServicesTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   test "generating application service definitions" do
     assert [

--- a/test/cachex/services_test.exs
+++ b/test/cachex/services_test.exs
@@ -10,7 +10,7 @@ defmodule Cachex.ServicesTest do
 
   test "generating default cache specifications" do
     # generate the test cache state
-    name = Helper.create_cache()
+    name = TestUtils.create_cache()
     cache = Services.Overseer.retrieve(name)
 
     # validate the services
@@ -30,7 +30,7 @@ defmodule Cachex.ServicesTest do
 
   test "skipping cache janitor specifications" do
     # generate the test cache state with the Janitor disabled
-    name = Helper.create_cache(expiration: expiration(interval: nil))
+    name = TestUtils.create_cache(expiration: expiration(interval: nil))
     cache = Services.Overseer.retrieve(name)
 
     # validate the services
@@ -49,7 +49,7 @@ defmodule Cachex.ServicesTest do
 
   test "locating running services" do
     # generate the test cache state with the Janitor disabled
-    name = Helper.create_cache(expiration: expiration(interval: nil))
+    name = TestUtils.create_cache(expiration: expiration(interval: nil))
     cache = Services.Overseer.retrieve(name)
 
     # validate the service locations

--- a/test/cachex/spec/validator_test.exs
+++ b/test/cachex/spec/validator_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.Spec.ValidatorTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   alias Cachex.Spec.Validator
 

--- a/test/cachex/spec/validator_test.exs
+++ b/test/cachex/spec/validator_test.exs
@@ -232,7 +232,7 @@ defmodule Cachex.Spec.ValidatorTest do
 
   test "validation of warmer records" do
     # create a warmer for validation
-    Helper.create_warmer(:validator_warmer, 1000, fn _ ->
+    TestUtils.create_warmer(:validator_warmer, 1000, fn _ ->
       :ignore
     end)
 

--- a/test/cachex/spec_test.exs
+++ b/test/cachex/spec_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.SpecTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   test "default command record values",
     do: assert(command() == {:command, nil, nil})

--- a/test/cachex/stats_test.exs
+++ b/test/cachex/stats_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.StatsTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   # This test ensures that we correctly register the clear action. When we clear
   # a cache, we need to increment the eviction count by the number of entries

--- a/test/cachex/stats_test.exs
+++ b/test/cachex/stats_test.exs
@@ -8,7 +8,7 @@ defmodule Cachex.StatsTest do
   # by 1 (as clearing is a single cache op).
   test "registering clear actions" do
     # create a test cache
-    cache = Helper.create_cache(stats: true)
+    cache = TestUtils.create_cache(stats: true)
 
     # set a few values in the cache
     for i <- 0..4 do
@@ -40,7 +40,7 @@ defmodule Cachex.StatsTest do
   # the result of the call (which is either true or false) under the del namespace.
   test "registering delete actions" do
     # create a test cache
-    cache = Helper.create_cache(stats: true)
+    cache = TestUtils.create_cache(stats: true)
 
     # set a few values in the cache
     for i <- 0..1 do
@@ -73,7 +73,7 @@ defmodule Cachex.StatsTest do
   # the global namespace based on whether the key exists or not.
   test "registering exists? actions" do
     # create a test cache
-    cache = Helper.create_cache(stats: true)
+    cache = TestUtils.create_cache(stats: true)
 
     # set a value in the cache
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -106,7 +106,7 @@ defmodule Cachex.StatsTest do
   # based on whether the key was in the cache.
   test "registering get actions" do
     # create a test cache
-    cache = Helper.create_cache(stats: true)
+    cache = TestUtils.create_cache(stats: true)
 
     # set a value in the cache
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -140,7 +140,7 @@ defmodule Cachex.StatsTest do
   # will also increment the miss count (as a key must miss in order to fall back).
   test "registering fetch actions" do
     # create a test cache
-    cache = Helper.create_cache(stats: true)
+    cache = TestUtils.create_cache(stats: true)
 
     # set a value in the cache
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -177,7 +177,7 @@ defmodule Cachex.StatsTest do
   # increment the updateCount. Both increment the operation count.
   test "registering incr/decr actions" do
     # create a test cache
-    cache = Helper.create_cache(stats: true)
+    cache = TestUtils.create_cache(stats: true)
 
     # incr values in the cache
     {:ok, 5} = Cachex.incr(cache, 1, 3, initial: 2)
@@ -218,7 +218,7 @@ defmodule Cachex.StatsTest do
 
     # create a test cache
     cache =
-      Helper.create_cache(
+      TestUtils.create_cache(
         stats: true,
         commands: [
           last: command(type: :read, execute: last),
@@ -265,7 +265,7 @@ defmodule Cachex.StatsTest do
   # evictionCount. This is because purged keys are removed due to TTL expiration.
   test "registering purge actions" do
     # create a test cache
-    cache = Helper.create_cache(stats: true)
+    cache = TestUtils.create_cache(stats: true)
 
     # set a few values in the cache
     for i <- 0..4 do
@@ -301,7 +301,7 @@ defmodule Cachex.StatsTest do
   # set namespace, in order to avoid false positives.
   test "registering put actions" do
     # create a test cache
-    cache = Helper.create_cache(stats: true)
+    cache = TestUtils.create_cache(stats: true)
 
     # set a few values in the cache
     for i <- 0..4 do
@@ -327,7 +327,7 @@ defmodule Cachex.StatsTest do
   # writing a batch will correctly count using the length of the batch itself.
   test "registering put_many actions" do
     # create a test cache
-    cache = Helper.create_cache(stats: true)
+    cache = TestUtils.create_cache(stats: true)
 
     # set a few values in the cache
     {:ok, true} =
@@ -360,7 +360,7 @@ defmodule Cachex.StatsTest do
   # missCount instead. Both also increment keys inside the take namespace.
   test "registering take actions" do
     # create a test cache
-    cache = Helper.create_cache(stats: true)
+    cache = TestUtils.create_cache(stats: true)
 
     # set a value in the cache
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -393,7 +393,7 @@ defmodule Cachex.StatsTest do
   # This test verifies the update actions and the incremenation of the necessary keys.
   test "registering update actions" do
     # create a test cache
-    cache = Helper.create_cache(stats: true)
+    cache = TestUtils.create_cache(stats: true)
 
     # set a value in the cache
     {:ok, true} = Cachex.put(cache, 1, 1)
@@ -422,7 +422,7 @@ defmodule Cachex.StatsTest do
   # module, so please refer to those tests for any issues with counters.
   test "retrieving the state of a stats hook" do
     # create a test cache
-    cache = Helper.create_cache(stats: true)
+    cache = TestUtils.create_cache(stats: true)
     cache = Services.Overseer.retrieve(cache)
 
     # retrieve the current time

--- a/test/cachex/test/case.ex
+++ b/test/cachex/test/case.ex
@@ -6,7 +6,7 @@ defmodule Cachex.Test.Case do
 
       alias Cachex.Test.Hook.Execute, as: ExecuteHook
       alias Cachex.Test.Hook.Forward, as: ForwardHook
-      alias Cachex.Test.Helper, as: Helper
+      alias Cachex.Test.Utils, as: TestUtils
       alias Cachex.Services
 
       import Cachex.Spec
@@ -15,7 +15,7 @@ defmodule Cachex.Test.Case do
 
       require ExecuteHook
       require ForwardHook
-      require Helper
+      require TestUtils
     end
   end
 end

--- a/test/cachex/test/case.ex
+++ b/test/cachex/test/case.ex
@@ -1,21 +1,21 @@
-defmodule CachexCase do
+defmodule Cachex.Test.Case do
   @doc false
   defmacro __using__(_) do
     quote location: :keep do
       use ExUnit.Case, async: false
 
-      alias CachexCase.ExecuteHook
-      alias CachexCase.ForwardHook
-      alias CachexCase.Helper
+      alias Cachex.Test.Hook.Execute, as: ExecuteHook
+      alias Cachex.Test.Hook.Forward, as: ForwardHook
+      alias Cachex.Test.Helper, as: Helper
       alias Cachex.Services
 
       import Cachex.Spec
       import Cachex.Errors
       import ExUnit.CaptureLog
 
-      require Helper
       require ExecuteHook
       require ForwardHook
+      require Helper
     end
   end
 end

--- a/test/cachex/test/utils.ex
+++ b/test/cachex/test/utils.ex
@@ -1,4 +1,4 @@
-defmodule Cachex.Test.Helper do
+defmodule Cachex.Test.Utils do
   @moduledoc false
   # This module contains various helper functions for tests.
   #

--- a/test/cachex/warmer_test.exs
+++ b/test/cachex/warmer_test.exs
@@ -1,5 +1,5 @@
 defmodule Cachex.WarmerTest do
-  use CachexCase
+  use Cachex.Test.Case
 
   test "warmers which set basic values" do
     # create a test warmer to pass to the cache

--- a/test/cachex/warmer_test.exs
+++ b/test/cachex/warmer_test.exs
@@ -3,12 +3,12 @@ defmodule Cachex.WarmerTest do
 
   test "warmers which set basic values" do
     # create a test warmer to pass to the cache
-    Helper.create_warmer(:basic_warmer, 50, fn _ ->
+    TestUtils.create_warmer(:basic_warmer, 50, fn _ ->
       {:ok, [{1, 1}]}
     end)
 
     # create a cache instance with a warmer
-    cache = Helper.create_cache(warmers: [warmer(module: :basic_warmer)])
+    cache = TestUtils.create_cache(warmers: [warmer(module: :basic_warmer)])
 
     # check that the key was warmed
     assert Cachex.get!(cache, 1) == 1
@@ -16,12 +16,12 @@ defmodule Cachex.WarmerTest do
 
   test "warmers which set values with options" do
     # create a test warmer to pass to the cache
-    Helper.create_warmer(:options_warmer, 50, fn _ ->
+    TestUtils.create_warmer(:options_warmer, 50, fn _ ->
       {:ok, [{1, 1}], [ttl: 60000]}
     end)
 
     # create a cache instance with a warmer
-    cache = Helper.create_cache(warmers: [warmer(module: :options_warmer)])
+    cache = TestUtils.create_cache(warmers: [warmer(module: :options_warmer)])
 
     # check that the key was warmed
     assert Cachex.get!(cache, 1) == 1
@@ -32,12 +32,12 @@ defmodule Cachex.WarmerTest do
 
   test "warmers which don't set values" do
     # create a test warmer to pass to the cache
-    Helper.create_warmer(:ignore_warmer, 50, fn _ ->
+    TestUtils.create_warmer(:ignore_warmer, 50, fn _ ->
       :ignore
     end)
 
     # create a cache instance with a warmer
-    cache = Helper.create_cache(warmers: [warmer(module: :ignore_warmer)])
+    cache = TestUtils.create_cache(warmers: [warmer(module: :ignore_warmer)])
 
     # check that the cache is empty
     assert Cachex.empty?(!cache)
@@ -45,14 +45,14 @@ defmodule Cachex.WarmerTest do
 
   test "warmers which aren't blocking" do
     # create a test warmer to pass to the cache
-    Helper.create_warmer(:optional_warmer, 50, fn _ ->
+    TestUtils.create_warmer(:optional_warmer, 50, fn _ ->
       :timer.sleep(3000)
       {:ok, [{1, 1}]}
     end)
 
     # create a cache instance with a warmer
     warmer = warmer(module: :optional_warmer, required: false)
-    cache = Helper.create_cache(warmers: [warmer])
+    cache = TestUtils.create_cache(warmers: [warmer])
 
     # check that the key was not warmed
     assert Cachex.get!(cache, 1) == nil
@@ -60,7 +60,7 @@ defmodule Cachex.WarmerTest do
 
   test "providing warmers with states" do
     # create a test warmer to pass to the cache
-    Helper.create_warmer(:state_warmer, 50, fn state ->
+    TestUtils.create_warmer(:state_warmer, 50, fn state ->
       {:ok, [{"state", state}]}
     end)
 
@@ -69,7 +69,7 @@ defmodule Cachex.WarmerTest do
 
     # create a cache instance with a warmer
     cache =
-      Helper.create_cache(
+      TestUtils.create_cache(
         warmers: [warmer(module: :state_warmer, state: state)]
       )
 
@@ -79,12 +79,12 @@ defmodule Cachex.WarmerTest do
 
   test "triggering cache hooks from within warmers" do
     # create a test warmer to pass to the cache
-    Helper.create_warmer(:hook_warmer_optional, 15000, fn _ ->
+    TestUtils.create_warmer(:hook_warmer_optional, 15000, fn _ ->
       {:ok, [{1, 1}]}
     end)
 
     # create a test warmer to pass to the cache
-    Helper.create_warmer(:hook_warmer_required, 15000, fn _ ->
+    TestUtils.create_warmer(:hook_warmer_required, 15000, fn _ ->
       {:ok, [{2, 2}]}
     end)
 
@@ -92,7 +92,7 @@ defmodule Cachex.WarmerTest do
     hook = ForwardHook.create()
 
     # create a cache instance with a warmer and hook
-    Helper.create_cache(
+    TestUtils.create_cache(
       hooks: [hook],
       warmers: [
         warmer(module: :hook_warmer_optional, required: false),

--- a/test/cachex_test.exs
+++ b/test/cachex_test.exs
@@ -1,5 +1,5 @@
 defmodule CachexTest do
-  use CachexCase
+  use Cachex.Test.Case
   import Integer
 
   # Ensures that we're able to start a cache and link it to the current process.

--- a/test/cachex_test.exs
+++ b/test/cachex_test.exs
@@ -7,12 +7,12 @@ defmodule CachexTest do
   # sure that the cache dies once the spawned process does.
   test "cache start with a link" do
     # fetch some names
-    name1 = Helper.create_name()
-    name2 = Helper.create_name()
+    name1 = TestUtils.create_name()
+    name2 = TestUtils.create_name()
 
     # cleanup on exit
-    Helper.delete_on_exit(name1)
-    Helper.delete_on_exit(name2)
+    TestUtils.delete_on_exit(name1)
+    TestUtils.delete_on_exit(name2)
 
     # this process should live
     {:ok, pid1} = Cachex.start_link(name1)
@@ -39,12 +39,12 @@ defmodule CachexTest do
   # process should stay alive after the process terminates.
   test "cache start without a link" do
     # fetch some names
-    name1 = Helper.create_name()
-    name2 = Helper.create_name()
+    name1 = TestUtils.create_name()
+    name2 = TestUtils.create_name()
 
     # cleanup on exit
-    Helper.delete_on_exit(name1)
-    Helper.delete_on_exit(name2)
+    TestUtils.delete_on_exit(name1)
+    TestUtils.delete_on_exit(name2)
 
     # this process should live
     {:ok, pid1} = Cachex.start(name1)
@@ -71,10 +71,10 @@ defmodule CachexTest do
   # global ETS table which stores cache states in the background.
   test "cache start when application not started" do
     # fetch a name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # cleanup on exit (just in case)
-    Helper.delete_on_exit(name)
+    TestUtils.delete_on_exit(name)
 
     # ensure that we start the app on exit
     on_exit(fn -> Application.ensure_all_started(:cachex) end)
@@ -108,10 +108,10 @@ defmodule CachexTest do
   # avoid bloating the Supervision tree.
   test "cache start with invalid options" do
     # fetch a name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # cleanup on exit (just in case)
-    Helper.delete_on_exit(name)
+    TestUtils.delete_on_exit(name)
 
     # try to start a cache with invalid hook definitions
     {:error, reason} = Cachex.start_link(name, hooks: hook(module: Missing))
@@ -125,10 +125,10 @@ defmodule CachexTest do
   # by returning a small atom error saying that the cache name already exists.
   test "cache start with existing cache name" do
     # fetch a name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # cleanup on exit (just in case)
-    Helper.delete_on_exit(name)
+    TestUtils.delete_on_exit(name)
 
     # this cache should start successfully
     {:ok, pid} = Cachex.start_link(name)
@@ -152,7 +152,7 @@ defmodule CachexTest do
   # both execution with valid and invalid names to make sure we catch both.
   test "cache execution with an invalid name" do
     # fetch a name
-    name = Helper.create_name()
+    name = TestUtils.create_name()
 
     # try to execute a cache action against a missing cache and an invalid name
     {:error, reason1} = Cachex.execute(name, & &1)
@@ -197,7 +197,7 @@ defmodule CachexTest do
     end
 
     # create a basic test cache
-    cache = Helper.create_cache()
+    cache = TestUtils.create_cache()
 
     # validate an unsafe call to test handling
     assert_raise(Cachex.ExecutionError, fn ->

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,11 +1,17 @@
 # ensure that Cachex has been started
 Application.ensure_all_started(:cachex)
 
-# require test lib files
+# pattern to find test library files
 "#{Path.dirname(__ENV__.file)}/**/*.ex"
+# locate via Path
 |> Path.wildcard()
+# roughly sort by most nested
+|> Enum.sort_by(&String.length/1)
+# nested first
 |> Enum.reverse()
+# only attempt to import files
 |> Enum.filter(&(!File.dir?(&1)))
+# load each found module via Code
 |> Enum.each(&Code.require_file/1)
 
 # start ExUnit with skips

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,46 +2,11 @@
 Application.ensure_all_started(:cachex)
 
 # require test lib files
-"#{Path.dirname(__ENV__.file)}/lib/**/*"
+"#{Path.dirname(__ENV__.file)}/**/*.ex"
 |> Path.wildcard()
+|> Enum.reverse()
 |> Enum.filter(&(!File.dir?(&1)))
 |> Enum.each(&Code.require_file/1)
 
 # start ExUnit with skips
 ExUnit.start(exclude: [:skip])
-
-# internal module
-defmodule TestHelper do
-  @moduledoc false
-  # This module exists because we need a contextual helper in order to be able
-  # to execute the ExUnit callbacks. Therefore this module is just a wrapper of
-  # these callbacks, along with all macros and initial setup.
-  require ExUnit.Case
-
-  # require hook related macros
-  require CachexCase.ExecuteHook
-  require CachexCase.ForwardHook
-
-  # create default execute hook
-  CachexCase.ExecuteHook.bind(default_execute_hook: [])
-
-  # create default forward hook
-  CachexCase.ForwardHook.bind(default_forward_hook: [])
-
-  @doc false
-  # Schedules a cache to be deleted at the end of the current test context.
-  def delete_on_exit(name) do
-    on_exit("delete #{name}", fn ->
-      try do
-        Supervisor.stop(name)
-      catch
-        :exit, _ -> :ok
-      end
-    end)
-  end
-
-  @doc false
-  # Binding for on_exit due to some cyclic dependencies.
-  def on_exit(name, action),
-    do: ExUnit.Callbacks.on_exit(name, action)
-end


### PR DESCRIPTION
This PR will refactor a bunch of the test modules to load in a better way, with better logical layout in the test directory. I don't really know what I was thinking when I set it up the first time 😄 

The short story is that `CachexCase` is now replaced by `Cachex.Test.Case`, and all test code lives in a new `Cachex.Test` umbrella (not shipped with the library, of course). I managed to remove `TestHelper` and bake it into the default `Cachex.Test.Helper` so there's no longer a module definition warning on start. I'm not sure if this is backwards compatible... we'll see.

I might rename `Helper` to `Utils`, to avoid confusion with `test_helper.exs`. This would be `Cachex.Test.Utils` and probably re-aliases to `TestUtils` within `Cachex.Test.Case` for convenience.  