### PR TITLE
Minor updates to documentation to slim down README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Cachex is an extremely fast in-memory key/value store with support for many usef
 
 All of these features are optional and are off by default so you can pick and choose those you wish to enable.
 
-Please visit the [documentation](docs) for further information on all available options and features.
-
 ## Installation
 
 As of v0.8, Cachex is available on [Hex](https://hex.pm/). You can install the package via:
@@ -32,7 +30,7 @@ end
 
 ## Usage
 
-In the most typical use of Cachex, you only need to add your cache as a child of your application. If you created your project via `Mix` (passing the `--sup` flag) this is handled in `lib/my_app/application.ex`. This file will already contain an empty list of children to add to your application - simply add entries for your cache to this list:
+In general use of Cachex, you'll likely only need to add your cache as a child of your application. If you created your project via `Mix`, this is usually handled in `lib/my_app/application.ex`:
 
 ```elixir
 children = [
@@ -40,13 +38,45 @@ children = [
 ]
 ```
 
-If you wish to start a cache manually (for example, in `iex`), you can just use `Cachex.start_link/2`:
+If you wish to start a cache manually (for example, in `iex`), you can use `Cachex.start_link/2`:
 
 ```elixir
 Cachex.start_link(name: :my_cache)
 ```
 
-For anything else, please see the [documentation](docs).
+Once your cache has started, you can call any of the main Cachex API using the name of your cache. In the interest of convenience, all Cachex actions have an automatically generated "unsafe" equivalent (appended with `!`):
+
+```elixir
+iex(1)> Cachex.get(:my_cache, "key")
+{:ok, nil}
+iex(2)> Cachex.get!(:my_cache, "key")
+nil
+iex(3)> Cachex.get(:missing_cache, "key")
+{:error, :no_cache}
+iex(4)> Cachex.get!(:missing_cache, "key")
+** (Cachex.ExecutionError) Specified cache not running
+    (cachex) lib/cachex.ex:249: Cachex.get!/3
+```
+
+Generally you should use the non-`!` versions to be more explicit in your code, but the `!` version exists for convenience and to make assertions easier in unit testing.
+
+## Options
+
+Caches also support many options provided at startup. These options are defined on a per-cache basis and can be used to control the features available to the cache.
+
+|      Options     |          Values          |                             Description                            |
+|:----------------:|:------------------------:|:------------------------------------------------------------------:|
+|     commands     |      map or keyword      |       A collection of custom commands to attach to the cache.      |
+|    expiration    |      `expiration()`      |      An expiration options record imported from Cachex.Spec.       |
+|     fallback     | function or `fallback()` |            A fallback record imported from Cachex.Spec.            |
+|       hooks      |     list of `hook()`     |        A list of execution hooks to listen on cache actions.       |
+|       limit      |    a `limit()` record    |    An integer or Limit struct to define the bounds of this cache.  |
+|       stats      |          boolean         |         Whether to track statistics for this cache or not.         |
+|   transactions   |          boolean         |           Whether to turn on transactions at cache start.          |
+|      warmers     |    list of `warmer()`    |           A list of cache warmers to enable on the cache.
+
+
+For anything further information on these features, please see the [documentation](docs).
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you wish to start a cache manually (for example, in `iex`), you can use `Cach
 Cachex.start_link(name: :my_cache)
 ```
 
-Once your cache has started, you can call any of the main Cachex API using the name of your cache. In the interest of convenience, all Cachex actions have an automatically generated "unsafe" equivalent (appended with `!`):
+Once your cache has started you can call any of the main Cachex API using the name of your cache. All Cachex actions have an automatically generated "unsafe" equivalent (appended with `!`):
 
 ```elixir
 iex(1)> Cachex.get(:my_cache, "key")
@@ -76,7 +76,7 @@ Caches also support many options provided at startup. These options are defined 
 |      warmers     |    list of `warmer()`    |           A list of cache warmers to enable on the cache.
 
 
-For anything further information on these features, please see the [documentation](docs).
+For further information or examples on these features and options, please see the Cachex [documentation](docs).
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -18,49 +18,7 @@ Cachex is an extremely fast in-memory key/value store with support for many usef
 
 All of these features are optional and are off by default so you can pick and choose those you wish to enable.
 
-## Table of Contents
-
-- [Installation](#installation)
-- [Getting Started](docs/getting-started.md)
-    - [Starting Your Cache](docs/getting-started.md#starting-your-cache)
-    - [Main Interface](docs/getting-started.md#main-interface)
-- [Action Blocks](docs/features/action-blocks.md)
-    - [Execution Blocks](docs/features/action-blocks.md#execution-blocks)
-    - [Transaction Blocks](docs/features/action-blocks.md#transaction-blocks)
-- [Cache Limits](docs/features/cache-limits.md)
-    - [Configuration](docs/features/cache-limits.md#configuration)
-    - [Policies](docs/features/cache-limits.md#policies)
-- [Cache Warming](docs/features/cache-warming)
-    - [Reactive Warming](docs/features/cache-warming/reactive-warming.md)
-        - [Overview](docs/features/cache-warming/reactive-warming.md#overview)
-        - [Courier](docs/features/cache-warming/reactive-warming.md#courier)
-        - [Expirations](docs/features/cache-warming/reactive-warming.md#expirations)
-        - [Use Cases](docs/features/cache-warming/reactive-warming.md#use-cases)
-    - [Proactive Warming](docs/features/cache-warming/proactive-warming.md)
-        - [Overview](docs/features/cache-warming/proactive-warming.md#overview)
-        - [Definition](docs/features/cache-warming/proactive-warming.md#definition)
-        - [Use Cases](docs/features/cache-warming/proactive-warming.md#use-cases)
-- [Custom Commands](docs/features/custom-commands.md)
-    - [Defining Commands](docs/features/custom-commands.md#defining-commands)
-    - [Invoking A Command](docs/features/custom-commands.md#invoking-a-command)
-- [Disk Interaction](docs/features/disk-interaction.md)
-- [Distributed Caches](docs/features/distributed-caches.md)
-    - [Overview](docs/features/distributed-caches.md#overview)
-    - [Local Actions](docs/features/distributed-caches.md#local-actions)
-    - [Disabled Actions](docs/features/distributed-caches.md#disabled-actions)
-- [Execution Hooks](docs/features/execution-hooks.md)
-    - [Creating Hooks](docs/features/execution-hooks.md#creating-hooks)
-    - [Provisions](docs/features/execution-hooks.md#provisions)
-- [Streaming Caches](docs/features/streaming-caches.md)
-    - [Complex Streaming](docs/features/streaming-caches.md#complex-streaming)
-- [TTL Implementation](docs/features/ttl-implementation.md)
-    - [Janitor Processes](docs/features/ttl-implementation.md#janitor-processes)
-    - [Lazy Expiration](docs/features/ttl-implementation.md#lazy-expiration)
-- [Migrations](docs/migrations)
-    - [Migrating To v3.x](docs/migrations/migrating-to-v3.md)
-    - [Migrating To v2.x](docs/migrations/migrating-to-v2.md)
-- [Benchmarks](#benchmarks)
-- [Contributions](#contributions)
+Please visit the [documentation](docs) for further information on all available options and features.
 
 ## Installation
 
@@ -88,7 +46,7 @@ If you wish to start a cache manually (for example, in `iex`), you can just use 
 Cachex.start_link(name: :my_cache)
 ```
 
-For anything else, please see the [documentation](https://github.com/whitfin/cachex/tree/master/docs).
+For anything else, please see the [documentation](docs).
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ Generally you should use the non-`!` versions to be more explicit in your code, 
 
 ## Options
 
-Caches also support many options provided at startup. These options are defined on a per-cache basis and can be used to control the features available to the cache.
+Caches also accept several options at startup to toggle various behaviour. These options are defined on a per-cache basis and can be used to control the features available to the cache:
 
 |      Options     |          Values          |                             Description                            |
 |:----------------:|:------------------------:|:------------------------------------------------------------------:|
 |     commands     |      map or keyword      |       A collection of custom commands to attach to the cache.      |
-|    expiration    |      `expiration()`      |      An expiration options record imported from Cachex.Spec.       |
-|     fallback     | function or `fallback()` |            A fallback record imported from Cachex.Spec.            |
+|    expiration    |      `expiration()`      |      An expiration options record imported from `Cachex.Spec`.     |
+|     fallback     | function or `fallback()` |            A fallback record imported from `Cachex.Spec`.          |
 |       hooks      |     list of `hook()`     |        A list of execution hooks to listen on cache actions.       |
 |       limit      |    a `limit()` record    |    An integer or Limit struct to define the bounds of this cache.  |
 |       stats      |          boolean         |         Whether to track statistics for this cache or not.         |
@@ -76,7 +76,7 @@ Caches also support many options provided at startup. These options are defined 
 |      warmers     |    list of `warmer()`    |           A list of cache warmers to enable on the cache.
 
 
-For further information or examples on these features and options, please see the Cachex [documentation](docs).
+For further information or examples on these features and options, please see the [documentation](docs).
 
 ## Benchmarks
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,8 @@
 # Cachex Documentation
 
-## Table of Contents
-
-- [Installation](../README.md#installation)
-- [Getting Started](#getting-started)
-    - [Starting Your Cache](#starting-your-cache)
-    - [Main Interface](#main-interface)
+- [Getting Started](../README.md#installation)
+    - [Starting Your Cache](../README.md#usage)
+    - [Supported Options](../README.md#options)
 - [Action Blocks](features/action-blocks.md)
     - [Execution Blocks](features/action-blocks.md#execution-blocks)
     - [Transaction Blocks](features/action-blocks.md#transaction-blocks)
@@ -43,49 +40,3 @@
     - [Migrating To v2.x](migrations/migrating-to-v2.md)
 - [Benchmarks](../README.md#benchmarks)
 - [Contributions](../README.md#contributions)
-
-## Getting Started
-
-### Starting Your Cache
-
-To start a cache you can use either `start/2` or `start_link/2`, and in general you should place it into your Supervision trees for fault tolerance. The first argument is the name of the cache and defines how you will communicate with your cache.
-
-```elixir
-Supervisor.start_link(
-  [{Cachex, name: :my_cache}],
-  [strategy: :one_for_one]
-)
-```
-
-The second and third arguments are both optional and represent cache and server options respectively. Cache options can be set on a cache at startup and cannot be modified. They're defined on a per-cache basis and control the features available to the cache. This table contains a summary of most of the available options, but please look at the module documentation either in GitHub or on Hexdocs for full documentation on what each one can configure.
-
-|      Options     |          Values          |                             Description                            |
-|:----------------:|:------------------------:|:------------------------------------------------------------------:|
-|     commands     |      map or keyword      |       A collection of custom commands to attach to the cache.      |
-|    expiration    |      `expiration()`      |      An expiration options record imported from Cachex.Spec.       |
-|     fallback     | function or `fallback()` |            A fallback record imported from Cachex.Spec.            |
-|       hooks      |     list of `hook()`     |        A list of execution hooks to listen on cache actions.       |
-|       limit      |    a `limit()` record    |    An integer or Limit struct to define the bounds of this cache.  |
-|       stats      |          boolean         |         Whether to track statistics for this cache or not.         |
-|   transactions   |          boolean         |           Whether to turn on transactions at cache start.          |
-|      warmers     |    list of `warmer()`    |           A list of cache warmers to enable on the cache.          |
-
-### Main Interface
-
-The Cachex interface follows a specific standard to make it easier to predict and more user friendly. All calls should follow the pattern of having the cache argument first, followed by any required arguments and ending with an optional list of options (even if no options are currently used). All calls should result in a value in the format of `{ status, result }` where `status` is usually `:ok` or `:error` (however this differs depending on the call). The `result` can basically be anything, as there are a number of custom controlled return values available inside Cachex.
-
-In the interest of convenience all Cachex actions have an automatically generated "unsafe" equivalent (appended with `!`) which unwraps these result Tuples. This unwrapping assumes that `:error` status means that the result should be raised, and that any other status should just return the result itself.
-
-```elixir
-iex(1)> Cachex.get(:my_cache, "key")
-{:ok, nil}
-iex(2)> Cachex.get!(:my_cache, "key")
-nil
-iex(3)> Cachex.get(:missing_cache, "key")
-{:error, :no_cache}
-iex(4)> Cachex.get!(:missing_cache, "key")
-** (Cachex.ExecutionError) Specified cache not running
-    (cachex) lib/cachex.ex:249: Cachex.get!/3
-```
-
-In production code I would typically recommend the safer versions to be explicit but the `!` version exists for both convenience and unit test code to make assertions easier.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,52 @@
-# Getting Started
+# Cachex Documentation
 
-## Starting Your Cache
+## Table of Contents
+
+- [Installation](../README.md#installation)
+- [Getting Started](#getting-started)
+    - [Starting Your Cache](#starting-your-cache)
+    - [Main Interface](#main-interface)
+- [Action Blocks](features/action-blocks.md)
+    - [Execution Blocks](features/action-blocks.md#execution-blocks)
+    - [Transaction Blocks](features/action-blocks.md#transaction-blocks)
+- [Cache Limits](features/cache-limits.md)
+    - [Configuration](features/cache-limits.md#configuration)
+    - [Policies](features/cache-limits.md#policies)
+- [Cache Warming](features/cache-warming)
+    - [Reactive Warming](features/cache-warming/reactive-warming.md)
+        - [Overview](features/cache-warming/reactive-warming.md#overview)
+        - [Courier](features/cache-warming/reactive-warming.md#courier)
+        - [Expirations](features/cache-warming/reactive-warming.md#expirations)
+        - [Use Cases](features/cache-warming/reactive-warming.md#use-cases)
+    - [Proactive Warming](features/cache-warming/proactive-warming.md)
+        - [Overview](features/cache-warming/proactive-warming.md#overview)
+        - [Definition](features/cache-warming/proactive-warming.md#definition)
+        - [Use Cases](features/cache-warming/proactive-warming.md#use-cases)
+- [Custom Commands](features/custom-commands.md)
+    - [Defining Commands](features/custom-commands.md#defining-commands)
+    - [Invoking A Command](features/custom-commands.md#invoking-a-command)
+- [Disk Interaction](features/disk-interaction.md)
+- [Distributed Caches](features/distributed-caches.md)
+    - [Overview](features/distributed-caches.md#overview)
+    - [Local Actions](features/distributed-caches.md#local-actions)
+    - [Disabled Actions](features/distributed-caches.md#disabled-actions)
+- [Execution Hooks](features/execution-hooks.md)
+    - [Creating Hooks](features/execution-hooks.md#creating-hooks)
+    - [Provisions](features/execution-hooks.md#provisions)
+- [Streaming Caches](features/streaming-caches.md)
+    - [Complex Streaming](features/streaming-caches.md#complex-streaming)
+- [TTL Implementation](features/ttl-implementation.md)
+    - [Janitor Processes](features/ttl-implementation.md#janitor-processes)
+    - [Lazy Expiration](features/ttl-implementation.md#lazy-expiration)
+- [Migrations](migrations)
+    - [Migrating To v3.x](migrations/migrating-to-v3.md)
+    - [Migrating To v2.x](migrations/migrating-to-v2.md)
+- [Benchmarks](../README.md#benchmarks)
+- [Contributions](../README.md#contributions)
+
+## Getting Started
+
+### Starting Your Cache
 
 To start a cache you can use either `start/2` or `start_link/2`, and in general you should place it into your Supervision trees for fault tolerance. The first argument is the name of the cache and defines how you will communicate with your cache.
 
@@ -24,7 +70,7 @@ The second and third arguments are both optional and represent cache and server 
 |   transactions   |          boolean         |           Whether to turn on transactions at cache start.          |
 |      warmers     |    list of `warmer()`    |           A list of cache warmers to enable on the cache.          |
 
-## Main Interface
+### Main Interface
 
 The Cachex interface follows a specific standard to make it easier to predict and more user friendly. All calls should follow the pattern of having the cache argument first, followed by any required arguments and ending with an optional list of options (even if no options are currently used). All calls should result in a value in the format of `{ status, result }` where `status` is usually `:ok` or `:error` (however this differs depending on the call). The `result` can basically be anything, as there are a number of custom controlled return values available inside Cachex.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Cachex Documentation
 
 - [Getting Started](../README.md#installation)
-    - [Starting Your Cache](../README.md#usage)
+    - [Starting A Cache](../README.md#usage)
     - [Supported Options](../README.md#options)
 - [Action Blocks](features/action-blocks.md)
     - [Execution Blocks](features/action-blocks.md#execution-blocks)


### PR DESCRIPTION
This PR moves some of the documentation around to reduce the noise inside README.md. Not much content has changed, and the user is directed over - it just makes it a little friendlier to scroll down to the usage/options section.