### PR TITLE
Remove fallback options from cache states

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ children = [
 ]
 ```
 
-If you wish to start a cache manually (for example, in `iex`), you can use `Cachex.start_link/1`:
+If you wish to start a cache manually (for example, in `iex`), you can use `Cachex.start_link/2`:
 
 ```elixir
 Cachex.start_link(name: :my_cache)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Caches also accept several options at startup to toggle various behaviour. These
 |:----------------:|:------------------------:|:------------------------------------------------------------------:|
 |     commands     |      map or keyword      |       A collection of custom commands to attach to the cache.      |
 |    expiration    |      `expiration()`      |      An expiration options record imported from `Cachex.Spec`.     |
-|     fallback     | function or `fallback()` |            A fallback record imported from `Cachex.Spec`.          |
 |       hooks      |     list of `hook()`     |        A list of execution hooks to listen on cache actions.       |
 |       limit      |    a `limit()` record    |    An integer or Limit struct to define the bounds of this cache.  |
 |       stats      |          boolean         |         Whether to track statistics for this cache or not.         |

--- a/docs/extensions/custom-commands.md
+++ b/docs/extensions/custom-commands.md
@@ -6,7 +6,7 @@ Commands operate in such a way that they're marginally quicker than hand-writing
 
 ## Defining a Command
 
-Commands are defined on a per-cache basis via the `:commands` flag inside the `Cachex.start_link/1` options.
+Commands are defined on a per-cache basis via the `:commands` flag inside the `Cachex.start_link/2` options.
 
 There are two types of command, either `:read` or `:write`. As you might guess the former will return a modified value from within a cache, while the latter will modify the value inside the cache before returning it.
 

--- a/docs/extensions/execution-lifecycle.md
+++ b/docs/extensions/execution-lifecycle.md
@@ -32,7 +32,7 @@ defmodule MyProject.MyHook do
 end
 ```
 
-Once you have your `Cachex.Hook` definition, you can attach it to a cache a startup using the `:hooks` option on the `Cachex.start_link/1` interface. This option accepts a list of `Cachex.Spec.hook` records and attaches them to the cache on launch:
+Once you have your `Cachex.Hook` definition, you can attach it to a cache a startup using the `:hooks` option on the `Cachex.start_link/2` interface. This option accepts a list of `Cachex.Spec.hook` records and attaches them to the cache on launch:
 
 ```elixir
 # need the records

--- a/docs/management/expiring-records.md
+++ b/docs/management/expiring-records.md
@@ -48,7 +48,7 @@ Naturally this technique cannot stand alone as it only evicts on key retrieval; 
 
 There are a number of ways to provide expirations for entries inside a cache:
 
-* Setting a default expiration for a cahe via `Cachex.start_link/1`
+* Setting a default expiration for a cahe via `Cachex.start_link/2`
 * Setting an expiration manually via `Cachex.expire/4` or `Cachex.expire_at/4`
 * Setting the `:expire` option within calls to `Cachex.put/4` or `Cachex.put_many/3`
 * Setting the `:expire` option within return tuples in `Cachex.fetch/4` or `Cachex.get_and_update/4`

--- a/docs/warming/proactive-warming.md
+++ b/docs/warming/proactive-warming.md
@@ -6,7 +6,7 @@ Warmers are deliberately easy to create, as anything complicated belongs outside
 
 ## Defining a Warmer
 
-First of all, let's define our warmer on a cache at startup. This is done by passing a list of `warmer()` records inside the `:warmers` option of `Cachex.start_link/1`:
+First of all, let's define our warmer on a cache at startup. This is done by passing a list of `warmer()` records inside the `:warmers` option of `Cachex.start_link/2`:
 
 ```elixir
 # for warmer()

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -303,10 +303,9 @@ defmodule Cachex do
       Please see the `Cachex.Spec.warmer/1` documentation for further customization options.
 
   """
-  @spec start_link(atom | Keyword.t()) :: {atom, pid}
-  def start_link(options) when is_list(options) do
-    with {:ok, name} <- Keyword.fetch(options, :name),
-         {:ok, true} <- ensure_started(),
+  @spec start_link(atom, Keyword.t()) :: {atom, pid}
+  def start_link(name, options \\ []) when is_atom(name) and is_list(options) do
+    with {:ok, true} <- ensure_started(),
          {:ok, true} <- ensure_unused(name),
          {:ok, cache} <- Options.parse(name, options),
          {:ok, pid} = Supervisor.start_link(__MODULE__, cache, name: name),
@@ -317,17 +316,6 @@ defmodule Cachex do
       {:ok, pid}
     end
   end
-
-  def start_link(name) when not is_atom(name),
-    do: error(:invalid_name)
-
-  def start_link(name),
-    do: start_link(name: name)
-
-  @doc false
-  @spec start_link(atom, Keyword.t()) :: {atom, pid}
-  def start_link(name, options),
-    do: start_link([name: name] ++ options)
 
   @doc """
   Creates a new Cachex cache service tree.

--- a/lib/cachex/actions/fetch.ex
+++ b/lib/cachex/actions/fetch.ex
@@ -31,7 +31,7 @@ defmodule Cachex.Actions.Fetch do
   """
   def execute(cache() = cache, key, fallback, _options) do
     with {:ok, nil} <- Get.execute(cache, key, []) do
-      Courier.dispatch(cache, key, generate_task(cache, fallback, key))
+      Courier.dispatch(cache, key, generate_task(fallback, key))
     end
   end
 
@@ -40,15 +40,10 @@ defmodule Cachex.Actions.Fetch do
   ###############
 
   # Generates a courier task based on the arity of the fallback function.
-  #
-  # If only a single argument is expected, the key alone is passed through. For
-  # any other arity, we pass through the key and the default state (which can
-  # be nil). This will therefore crash if the provided arity is invalid.
-  defp generate_task(cache(fallback: fallback(state: state)), fallback, key) do
+  defp generate_task(fallback, key) do
     case :erlang.fun_info(fallback)[:arity] do
       0 -> fn -> fallback.() end
       1 -> fn -> fallback.(key) end
-      _ -> fn -> fallback.(key, state) end
     end
   end
 end

--- a/lib/cachex/actions/import.ex
+++ b/lib/cachex/actions/import.ex
@@ -22,6 +22,10 @@ defmodule Cachex.Actions.Import do
   def execute(cache() = cache, entries, _options),
     do: {:ok, Enum.reduce(entries, 0, &import(cache, &1, &2, now()))}
 
+  ###############
+  # Private API #
+  ###############
+
   # Imports an entry directly when no TTL is included.
   #
   # As this is a direct import, we just use `Cachex.put/4` with the provided

--- a/lib/cachex/actions/restore.ex
+++ b/lib/cachex/actions/restore.ex
@@ -47,6 +47,10 @@ defmodule Cachex.Actions.Restore do
     File.Error -> error(:unreachable_file)
   end
 
+  ###############
+  # Private API #
+  ###############
+
   # Read the next term from a file handle cbased on the TLV flags. Each
   # term should be emitted back to the parent stream for processing.
   defp read_next_term(file, options) do

--- a/lib/cachex/actions/save.ex
+++ b/lib/cachex/actions/save.ex
@@ -48,6 +48,10 @@ defmodule Cachex.Actions.Save do
     File.Error -> error(:unreachable_file)
   end
 
+  ###############
+  # Private API #
+  ###############
+
   # Use a local stream to lazily walk through records on a local cache.
   defp init_stream(local, router, cache, batch) when local or router == Local,
     do: CachexStream.execute(cache, Query.build(), batch_size: batch)

--- a/lib/cachex/errors.ex
+++ b/lib/cachex/errors.ex
@@ -18,7 +18,6 @@ defmodule Cachex.Errors do
     :invalid_hook,
     :invalid_limit,
     :invalid_match,
-    :invalid_name,
     :invalid_option,
     :invalid_pairs,
     :invalid_router,
@@ -82,9 +81,6 @@ defmodule Cachex.Errors do
 
   def long_form(:invalid_match),
     do: "Invalid match specification provided"
-
-  def long_form(:invalid_name),
-    do: "Invalid cache name provided"
 
   def long_form(:invalid_option),
     do: "Invalid option syntax provided"

--- a/lib/cachex/errors.ex
+++ b/lib/cachex/errors.ex
@@ -15,7 +15,6 @@ defmodule Cachex.Errors do
     :cross_slot,
     :invalid_command,
     :invalid_expiration,
-    :invalid_fallback,
     :invalid_hook,
     :invalid_limit,
     :invalid_match,
@@ -74,9 +73,6 @@ defmodule Cachex.Errors do
 
   def long_form(:invalid_expiration),
     do: "Invalid expiration definition provided"
-
-  def long_form(:invalid_fallback),
-    do: "Invalid fallback function provided"
 
   def long_form(:invalid_hook),
     do: "Invalid hook definition provided"

--- a/lib/cachex/options.ex
+++ b/lib/cachex/options.ex
@@ -22,7 +22,6 @@ defmodule Cachex.Options do
     :router,
     :ordered,
     :commands,
-    :fallback,
     :compressed,
     :expiration,
     :transactions,
@@ -190,38 +189,6 @@ defmodule Cachex.Options do
     case Validator.valid?(:expiration, expiration) do
       false -> error(:invalid_expiration)
       true -> cache(cache, expiration: expiration)
-    end
-  end
-
-  # Sets up any cache-wide fallback behaviour.
-  #
-  # This will allow the shorthanding of a function to act as a default
-  # fallback implementation; otherwise the provided value must be a
-  # fallback record which is run through the specification validation.
-  defp parse_type(:fallback, cache, options) do
-    fallback =
-      transform(options, :fallback, fn
-        # provided fallback is great!
-        fallback() = fallback ->
-          fallback
-
-        # allow shorthand of a function
-        fun when is_function(fun) ->
-          fallback(default: fun)
-
-        # unset so default
-        nil ->
-          fallback()
-
-        # anything else, no thanks!
-        _invalid ->
-          nil
-      end)
-
-    # validate using the spec validator
-    case Validator.valid?(:fallback, fallback) do
-      false -> error(:invalid_fallback)
-      true -> cache(cache, fallback: fallback)
     end
   end
 

--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -38,7 +38,6 @@ defmodule Cachex.Spec do
             commands: map,
             compressed: boolean,
             expiration: expiration,
-            fallback: fallback,
             hooks: hooks,
             limit: limit,
             ordered: boolean,
@@ -72,13 +71,6 @@ defmodule Cachex.Spec do
             default: non_neg_integer,
             interval: non_neg_integer | nil,
             lazy: boolean
-          )
-
-  # Record specification for a cache fallback
-  @type fallback ::
-          record(:fallback,
-            default: (any -> any) | (any, any -> any),
-            state: any
           )
 
   # Record specification for a cache hook
@@ -139,7 +131,6 @@ defmodule Cachex.Spec do
     commands: %{},
     compressed: false,
     expiration: nil,
-    fallback: nil,
     hooks: nil,
     limit: nil,
     ordered: false,
@@ -200,17 +191,6 @@ defmodule Cachex.Spec do
     default: nil,
     interval: 3000,
     lazy: true
-
-  @doc """
-  Creates a fallback record from the provided values.
-
-  A fallback can consist of a nillable state to provide to a fallback definition when
-  requested (via a fallback with an arity of 2). If a default action is provided, it
-  should be a function of arity 1 or 2, depending on if it requires the state or not.
-  """
-  defrecord :fallback,
-    default: nil,
-    state: nil
 
   @doc """
   Creates a hook record from the provided values.
@@ -322,12 +302,6 @@ defmodule Cachex.Spec do
   """
   @spec expiration(expiration, Keyword.t()) :: expiration
   defmacro expiration(record, args)
-
-  @doc """
-  Updates a fallback record from the provided values.
-  """
-  @spec fallback(fallback, Keyword.t()) :: fallback
-  defmacro fallback(record, args)
 
   @doc """
   Updates a hook record from the provided values.

--- a/lib/cachex/spec/validator.ex
+++ b/lib/cachex/spec/validator.ex
@@ -62,13 +62,6 @@ defmodule Cachex.Spec.Validator do
     check3
   end
 
-  # Validates a fallback specification record.
-  #
-  # At this point it just needs to verify that the default value is a valid
-  # function. We can only support functions with arity 1 or 2.
-  def valid?(:fallback, fallback(default: default)),
-    do: nillable?(default, &(is_function(&1, 1) or is_function(&1, 2)))
-
   # Validates a hook specification record.
   #
   # This validation will ensure the following:

--- a/lib/cachex/spec/validator.ex
+++ b/lib/cachex/spec/validator.ex
@@ -15,7 +15,6 @@ defmodule Cachex.Spec.Validator do
           Cachex.Spec.command()
           | Cachex.Spec.entry()
           | Cachex.Spec.expiration()
-          | Cachex.Spec.fallback()
           | Cachex.Spec.hook()
           | Cachex.Spec.hooks()
           | Cachex.Spec.limit()

--- a/test/cachex/errors_test.exs
+++ b/test/cachex/errors_test.exs
@@ -9,7 +9,6 @@ defmodule Cachex.ErrorsTest do
       cross_slot: "Target keys do not live on the same node",
       invalid_command: "Invalid command definition provided",
       invalid_expiration: "Invalid expiration definition provided",
-      invalid_fallback: "Invalid fallback function provided",
       invalid_hook: "Invalid hook definition provided",
       invalid_limit: "Invalid limit fields provided",
       invalid_match: "Invalid match specification provided",

--- a/test/cachex/errors_test.exs
+++ b/test/cachex/errors_test.exs
@@ -12,7 +12,6 @@ defmodule Cachex.ErrorsTest do
       invalid_hook: "Invalid hook definition provided",
       invalid_limit: "Invalid limit fields provided",
       invalid_match: "Invalid match specification provided",
-      invalid_name: "Invalid cache name provided",
       invalid_option: "Invalid option syntax provided",
       invalid_pairs: "Invalid insertion pairs provided",
       invalid_router: "Invalid router definition provided",

--- a/test/cachex/options_test.exs
+++ b/test/cachex/options_test.exs
@@ -199,56 +199,6 @@ defmodule Cachex.OptionsTest do
     assert msg == :invalid_expiration
   end
 
-  # Every cache can have a default fallback implementation which is used in case
-  # of no fallback provided against cache reads. The only constraint here is that
-  # the provided value is a valid function (of any arity).
-  test "parsing :fallback flags" do
-    # grab a cache name
-    name = TestUtils.create_name()
-
-    # define our falbacks
-    fallback1 = fallback()
-    fallback2 = fallback(default: &String.reverse/1)
-    fallback3 = fallback(default: &String.reverse/1, state: {})
-    fallback4 = fallback(state: {})
-    fallback5 = &String.reverse/1
-    fallback6 = {}
-
-    # parse all the valid fallbacks into caches
-    {:ok, cache(fallback: fallback1)} =
-      Cachex.Options.parse(name, fallback: fallback1)
-
-    {:ok, cache(fallback: fallback2)} =
-      Cachex.Options.parse(name, fallback: fallback2)
-
-    {:ok, cache(fallback: fallback3)} =
-      Cachex.Options.parse(name, fallback: fallback3)
-
-    {:ok, cache(fallback: fallback4)} =
-      Cachex.Options.parse(name, fallback: fallback4)
-
-    {:ok, cache(fallback: fallback5)} =
-      Cachex.Options.parse(name, fallback: fallback5)
-
-    {:error, msg} = Cachex.Options.parse(name, fallback: fallback6)
-
-    # the first should use defaults
-    assert(fallback1 == fallback())
-
-    # the second and fifth should have an action but no state
-    assert(fallback2 == fallback(default: &String.reverse/1))
-    assert(fallback5 == fallback(default: &String.reverse/1))
-
-    # the third should have both an action and state
-    assert(fallback3 == fallback(default: &String.reverse/1, state: {}))
-
-    # the fourth should have a state but no action
-    assert(fallback4 == fallback(state: {}))
-
-    # an invalid fallback should actually fail
-    assert(msg == :invalid_fallback)
-  end
-
   # This test will ensure that we can parse Hook values successfully. Hooks can
   # be provided as either a List or a single Hook. We also need to check that
   # Hooks are grouped into the correct pre/post groups inside the state.

--- a/test/cachex/spec/validator_test.exs
+++ b/test/cachex/spec/validator_test.exs
@@ -94,28 +94,6 @@ defmodule Cachex.Spec.ValidatorTest do
     refute Validator.valid?(:expiration, expiration8)
   end
 
-  test "validation of fallback records" do
-    # define some valid records
-    fallback1 = fallback(default: nil, state: nil)
-    fallback2 = fallback(default: nil, state: " ")
-    fallback3 = fallback(default: fn _ -> nil end, state: nil)
-    fallback4 = fallback(default: fn _, _ -> nil end, state: nil)
-
-    # ensure all records are valid
-    assert Validator.valid?(:fallback, fallback1)
-    assert Validator.valid?(:fallback, fallback2)
-    assert Validator.valid?(:fallback, fallback3)
-    assert Validator.valid?(:fallback, fallback4)
-
-    # define some invalid records
-    fallback5 = fallback(default: " ", state: nil)
-    fallback6 = fallback(default: fn -> nil end, state: nil)
-
-    # ensure all records are invalid
-    refute Validator.valid?(:fallback, fallback5)
-    refute Validator.valid?(:fallback, fallback6)
-  end
-
   test "validation of hook records" do
     # define some valid records
     hook1 = hook(module: :validator_hook_pre)

--- a/test/cachex/spec_test.exs
+++ b/test/cachex/spec_test.exs
@@ -7,9 +7,6 @@ defmodule Cachex.SpecTest do
   test "default entry record values",
     do: assert(entry() == {:entry, nil, nil, nil, nil})
 
-  test "default fallback record values",
-    do: assert(fallback() == {:fallback, nil, nil})
-
   test "default expiration record values",
     do: assert(expiration() == {:expiration, nil, 3000, true})
 

--- a/test/cachex_test.exs
+++ b/test/cachex_test.exs
@@ -92,17 +92,6 @@ defmodule CachexTest do
     assert(reason == :not_started)
   end
 
-  # This test does a simple check that a cache must be started with a valid atom
-  # cache name, otherwise an error is raised (an ArgumentError). The error should
-  # be a shorthand atom which can be used to debug what the issue was.
-  test "cache start with invalid cache name" do
-    # try to start the cache with an invalid name
-    {:error, reason} = Cachex.start_link("fake_name")
-
-    # we should've received an atom warning
-    assert(reason == :invalid_name)
-  end
-
   # This test ensures that we handle option parsing errors gracefully. If anything
   # goes wrong when parsing options, we exit early before starting the cache to
   # avoid bloating the Supervision tree.

--- a/test/cachex_test.exs
+++ b/test/cachex_test.exs
@@ -177,7 +177,7 @@ defmodule CachexTest do
     assert(is_even(length(definitions)))
 
     # verify the size to cause errors on addition/removal
-    assert(length(definitions) == 148)
+    assert(length(definitions) == 146)
 
     # validate all definitions
     for {name, arity} <- definitions do


### PR DESCRIPTION
This fixes #371.

This will remove `:fallback` from the cache state, as well as the ability to add state to fallback functions. This simplifies handling, removes error checking in favour of guards, and makes the cache state smaller to copy.

If people require that `:state` be added back in future, this is not off the table and has been documented as such. I am fairly confident that it will not be required due to it being kinda anti-OTP (most people will have separate processes for their state, so they can just use the `:name`). 