### PR TITLE
Replace :initial with :default

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -400,7 +400,7 @@ defmodule Cachex do
 
   ## Options
 
-    * `:initial`
+    * `:default`
 
       An initial value to set the key to if it does not exist. This will
       take place *before* the decrement call. Defaults to 0.
@@ -415,7 +415,7 @@ defmodule Cachex do
       iex> Cachex.decr(:my_cache, "my_new_key", 5)
       { :ok, 5 }
 
-      iex> Cachex.decr(:my_cache, "missing_key", 5, initial: 2)
+      iex> Cachex.decr(:my_cache, "missing_key", 5, default: 2)
       { :ok, -3 }
 
   """
@@ -754,7 +754,7 @@ defmodule Cachex do
 
   ## Options
 
-    * `:initial`
+    * `:default`
 
       An initial value to set the key to if it does not exist. This will
       take place *before* the increment call. Defaults to 0.
@@ -769,7 +769,7 @@ defmodule Cachex do
       iex> Cachex.incr(:my_cache, "my_new_key", 5)
       { :ok, 15 }
 
-      iex> Cachex.incr(:my_cache, "missing_key", 5, initial: 2)
+      iex> Cachex.incr(:my_cache, "missing_key", 5, default: 2)
       { :ok, 7 }
 
   """

--- a/lib/cachex/stats.ex
+++ b/lib/cachex/stats.ex
@@ -275,7 +275,7 @@ defmodule Cachex.Stats do
 
     matcher = value + amount * offset
 
-    case Options.get(options, :initial, &is_integer/1, 0) do
+    case Options.get(options, :default, &is_integer/1, 0) do
       ^matcher ->
         increment(stats, [:writes], 1)
 

--- a/test/cachex/actions/decr_test.exs
+++ b/test/cachex/actions/decr_test.exs
@@ -12,7 +12,7 @@ defmodule Cachex.Actions.DecrTest do
     cache = TestUtils.create_cache(hooks: [hook])
 
     # define write options
-    opts1 = [initial: 10]
+    opts1 = [default: 10]
 
     # decrement some items
     decr1 = Cachex.decr(cache, "key1")

--- a/test/cachex/actions/incr_test.exs
+++ b/test/cachex/actions/incr_test.exs
@@ -12,7 +12,7 @@ defmodule Cachex.Actions.IncrTest do
     cache = TestUtils.create_cache(hooks: [hook])
 
     # define write options
-    opts1 = [initial: 10]
+    opts1 = [default: 10]
 
     # increment some items
     incr1 = Cachex.incr(cache, "key1")

--- a/test/cachex/stats_test.exs
+++ b/test/cachex/stats_test.exs
@@ -180,11 +180,11 @@ defmodule Cachex.StatsTest do
     cache = TestUtils.create_cache(stats: true)
 
     # incr values in the cache
-    {:ok, 5} = Cachex.incr(cache, 1, 3, initial: 2)
+    {:ok, 5} = Cachex.incr(cache, 1, 3, default: 2)
     {:ok, 6} = Cachex.incr(cache, 1)
 
     # decr values in the cache
-    {:ok, -5} = Cachex.decr(cache, 2, 3, initial: -2)
+    {:ok, -5} = Cachex.decr(cache, 2, 3, default: -2)
     {:ok, -6} = Cachex.decr(cache, 2)
 
     # retrieve the statistics


### PR DESCRIPTION
This fixes #370.

Replaces `:initial` with `:default` for consistency with other names.