### PR TITLE
Improve performance and lower overhead in Janitor services

### DIFF
--- a/docs/management/expiring-records.md
+++ b/docs/management/expiring-records.md
@@ -12,9 +12,7 @@ In the current version of Cachex, the Janitor is pretty well optimized as most o
 import Cachex.Spec
 
 Cachex.start(:my_cache, [
-    expiration: expiration(
-        interval: :timer.seconds(3)
-    )
+    expiration: expiration(interval: :timer.seconds(3))
 ])
 ```
 
@@ -34,9 +32,7 @@ There is a very minimal overhead to this lazy checking, and there are cases wher
 import Cachex.Spec
 
 Cachex.start(:my_cache, [
-    expiration: expiration(
-        lazy: false
-    )
+    expiration: expiration(lazy: false)
 ])
 ```
 
@@ -61,9 +57,7 @@ import Cachex.Spec
 
 # default for all entries
 Cachex.start(:my_cache, [
-    expiration: expiration(
-        default: :timer.seconds(60)
-    )
+    expiration: expiration(default: :timer.seconds(60))
 ])
 
 # setting an expiration manually
@@ -73,7 +67,7 @@ Cachex.expire(:my_cache, "key", :timer.seconds(60))
 # using the `Cachex.put/4` shorthand rather than setting manually
 Cachex.put(:my_cache, "key", "value", expire: :timer.seconds(60))
 
-# setting expiration via lazily computed values
+# setting expiration on lazily computed values
 Cachex.fetch(:my_cache, "key", fn ->
     { :commit, "value", expire: :timer.seconds(60) }
 end)

--- a/lib/cachex/actions/export.ex
+++ b/lib/cachex/actions/export.ex
@@ -5,7 +5,6 @@ defmodule Cachex.Actions.Export do
   # This command is extremely expensive as it turns the entire cache table into
   # a list, and so should be used sparingly. It's provided purely because it's
   # the backing implementation of the `Cachex.save/3` command.
-  alias Cachex.Actions.Stream, as: CachexStream
   alias Cachex.Query
 
   # add required imports
@@ -22,7 +21,10 @@ defmodule Cachex.Actions.Export do
   to the memory overhead involved, as well as the large concatenations.
   """
   def execute(cache() = cache, _options) do
-    with {:ok, stream} <- CachexStream.execute(cache, Query.build(), []) do
+    query = Query.build()
+    options = const(:local) ++ const(:notify_false)
+
+    with {:ok, stream} <- Cachex.stream(cache, query, options) do
       {:ok, Enum.to_list(stream)}
     end
   end

--- a/lib/cachex/actions/prune.ex
+++ b/lib/cachex/actions/prune.ex
@@ -7,7 +7,6 @@ defmodule Cachex.Actions.Prune do
   # exactly prune the table.
   #
   # This command is used by the various limit hooks provided by Cachex.
-  alias Cachex.Actions.Stream, as: CachexStream
   alias Cachex.Query
   alias Cachex.Services.Informant
 
@@ -88,7 +87,13 @@ defmodule Cachex.Actions.Prune do
   # naturally required when it comes to removing the document, and the touch time is
   # used to determine the sort order required for LRW.
   defp erase_lower_bound(offset, cache, batch) when offset > 0 do
-    with {:ok, stream} <- CachexStream.execute(cache, @query, batch_size: batch) do
+    options =
+      :local
+      |> const()
+      |> Enum.concat(const(:notify_false))
+      |> Enum.concat(batch_size: batch)
+
+    with {:ok, stream} <- Cachex.stream(cache, @query, options) do
       cache(name: name) = cache
 
       stream

--- a/lib/cachex/actions/reset.ex
+++ b/lib/cachex/actions/reset.ex
@@ -7,6 +7,7 @@ defmodule Cachex.Actions.Reset do
   #
   # This is not executed inside an action context as there is no need to
   # notify on reset (as otherwise a reset would always be the first message).
+  alias Cachex.Hook
   alias Cachex.Actions.Clear
   alias Cachex.Services.Locksmith
 
@@ -63,22 +64,20 @@ defmodule Cachex.Actions.Reset do
   # This has the ability to clear either all hooks or a subset of hooks. We have a small
   # optimization here to detect when we want to reset all hooks to avoid filtering without
   # a real need to. We also convert the list of hooks to a set to avoid O(N) lookups.
-  defp reset_hooks(cache(hooks: hooks(pre: pre, post: post)), only, opts) do
+  defp reset_hooks(cache(hooks: hooks), only, opts) do
     if :hooks in only do
-      case Keyword.get(opts, :hooks) do
-        nil ->
-          pre
-          |> Enum.concat(post)
-          |> Enum.each(&notify_reset/1)
+      hooks = Hook.concat(hooks)
 
-        val ->
-          hook_sets = List.wrap(val)
+      hooks =
+        case Keyword.get(opts, :hooks) do
+          nil ->
+            hooks
 
-          pre
-          |> Enum.concat(post)
-          |> Enum.filter(&should_reset?(&1, hook_sets))
-          |> Enum.each(&notify_reset/1)
-      end
+          val ->
+            Enum.filter(hooks, &should_reset?(&1, val))
+        end
+
+      Enum.each(hooks, &notify_reset/1)
     end
   end
 

--- a/lib/cachex/actions/save.ex
+++ b/lib/cachex/actions/save.ex
@@ -7,7 +7,6 @@ defmodule Cachex.Actions.Save do
   #
   # Backups can be imported again using the `Cachex.restore/3` command, and
   # should be ble to be transferred between processes and physical nodes.
-  alias Cachex.Actions.Stream, as: CachexStream
   alias Cachex.Options
   alias Cachex.Query
   alias Cachex.Router.Local
@@ -53,8 +52,15 @@ defmodule Cachex.Actions.Save do
   ###############
 
   # Use a local stream to lazily walk through records on a local cache.
-  defp init_stream(local, router, cache, batch) when local or router == Local,
-    do: CachexStream.execute(cache, Query.build(), batch_size: batch)
+  defp init_stream(local, router, cache, batch) when local or router == Local do
+    options =
+      :local
+      |> const()
+      |> Enum.concat(const(:notify_false))
+      |> Enum.concat(batch_size: batch)
+
+    Cachex.stream(cache, Query.build(), options)
+  end
 
   # Generate an export of all nodes in a distributed cluster via `Cachex.export/2`
   defp init_stream(_local, _router, cache, _batch),

--- a/lib/cachex/limit/scheduled.ex
+++ b/lib/cachex/limit/scheduled.ex
@@ -32,13 +32,6 @@ defmodule Cachex.Limit.Scheduled do
   ######################
 
   @doc """
-  Returns the actions this policy should listen on.
-  """
-  @spec actions :: [atom]
-  def actions,
-    do: []
-
-  @doc """
   Returns the provisions this policy requires.
   """
   @spec provisions :: [atom]

--- a/lib/cachex/options.ex
+++ b/lib/cachex/options.ex
@@ -209,10 +209,14 @@ defmodule Cachex.Options do
       true ->
         type = Enum.group_by(hooks, &hook(&1, :module).type())
 
-        pre = Map.get(type, :pre, [])
-        post = Map.get(type, :post, [])
+        hooks =
+          hooks(
+            pre: Map.get(type, :pre, []),
+            post: Map.get(type, :post, []),
+            service: Map.get(type, :service, [])
+          )
 
-        cache(cache, hooks: hooks(pre: pre, post: post))
+        cache(cache, hooks: hooks)
     end
   end
 

--- a/lib/cachex/router.ex
+++ b/lib/cachex/router.ex
@@ -331,9 +331,12 @@ defmodule Cachex.Router do
     end
   end
 
+  # coveralls-ignore-start
   # Catch-all just in case we missed something...
   defp route_cluster(_cache, _module, _call),
     do: error(:non_distributed)
+
+  # coveralls-ignore-stop
 
   # Calls a slot for the provided cache action if all keys slot to the same node.
   #

--- a/lib/cachex/services.ex
+++ b/lib/cachex/services.ex
@@ -69,10 +69,9 @@ defmodule Cachex.Services do
   the Supervisor children and place them in a modified cache record.
   """
   @spec link(Cachex.t()) :: {:ok, Cachex.t()}
-  def link(cache(hooks: hooks(pre: [], post: []), warmers: []) = cache),
-    do: {:ok, cache}
+  def link(cache(hooks: hooks, warmers: warmers) = cache) do
+    hooks(pre: pre, post: post, service: service) = hooks
 
-  def link(cache(hooks: hooks(pre: pre, post: post), warmers: warmers) = cache) do
     hook_children = find_children(cache, Services.Informant)
     warmer_children = find_children(cache, Services.Incubator)
 
@@ -81,7 +80,8 @@ defmodule Cachex.Services do
         hooks:
           hooks(
             pre: attach_child(pre, hook_children),
-            post: attach_child(post, hook_children)
+            post: attach_child(post, hook_children),
+            service: attach_child(service, hook_children)
           ),
         warmers: attach_child(warmers, warmer_children)
       )

--- a/lib/cachex/services.ex
+++ b/lib/cachex/services.ex
@@ -90,6 +90,19 @@ defmodule Cachex.Services do
   end
 
   @doc """
+  Returns a list of all running cache services.
+
+  This is used to view the children of the specified cache, whilst filtering
+  out any services which may not have been started based on the cache options.
+  """
+  @spec list(Cachex.t()) :: [Supervisor.Spec.spec()]
+  def list(cache(name: cache)) do
+    cache
+    |> Supervisor.which_children()
+    |> Enum.filter(&service?/1)
+  end
+
+  @doc """
   Retrieves the process identifier of the provided service.
 
   This will return `nil` if the service does not exist, or is not running.
@@ -97,21 +110,8 @@ defmodule Cachex.Services do
   @spec locate(Cachex.t(), atom) :: pid | nil
   def locate(cache() = cache, service) do
     cache
-    |> services
+    |> list
     |> find_pid(service)
-  end
-
-  @doc """
-  Returns a list of all running cache services.
-
-  This is used to view the children of the specified cache, whilst filtering
-  out any services which may not have been started based on the cache options.
-  """
-  @spec services(Cachex.t()) :: [Supervisor.Spec.spec()]
-  def services(cache(name: cache)) do
-    cache
-    |> Supervisor.which_children()
-    |> Enum.filter(&service?/1)
   end
 
   ###############

--- a/lib/cachex/services/janitor.ex
+++ b/lib/cachex/services/janitor.ex
@@ -111,6 +111,7 @@ defmodule Cachex.Services.Janitor do
   # need to be removed; they are then deleted by ETS at very high speeds.
   def handle_info(:purge, {cache, false, _last}) do
     started = now()
+    options = const(:local) ++ const(:notify_false)
 
     {duration, active} =
       :timer.tc(fn ->
@@ -122,7 +123,7 @@ defmodule Cachex.Services.Janitor do
           )
 
         cache
-        |> Cachex.stream!(query, const(:local) ++ const(:notify_false))
+        |> Cachex.stream!(query, options)
         |> Enum.empty?()
       end)
 

--- a/lib/cachex/services/janitor.ex
+++ b/lib/cachex/services/janitor.ex
@@ -12,15 +12,16 @@ defmodule Cachex.Services.Janitor do
   scans, so it should be expected that this can take a while to execute.
   """
   use GenServer
+  use Cachex.Provision
 
   # import parent macros
   import Cachex.Errors
   import Cachex.Spec
 
   # add some aliases
+  alias Cachex.Query
   alias Cachex.Services
   alias Services.Informant
-  alias Services.Overseer
 
   ##############
   # Public API #
@@ -88,14 +89,19 @@ defmodule Cachex.Services.Janitor do
   #
   # This will create the structure used to store metadata about
   # the run cycles of the Janitor, and schedule the first run.
-  def init(cache),
-    do: {:ok, {schedule_check(cache), %{}}}
+  def init(_),
+    do: {:ok, {nil, false, nil}}
+
+  @doc false
+  # Defines provisions required by this service.
+  def provisions,
+    do: [:cache]
 
   @doc false
   # Returns metadata about the last run of this Janitor.
   #
   # The returned information should be treated as non-guaranteed.
-  def handle_call(:last, _ctx, {_cache, last} = state),
+  def handle_call(:last, _ctx, {_cache, _active, last} = state),
     do: {:reply, {:ok, last}, state}
 
   @doc false
@@ -103,36 +109,89 @@ defmodule Cachex.Services.Janitor do
   #
   # This will drop to the ETS level and use a select to match documents which
   # need to be removed; they are then deleted by ETS at very high speeds.
-  def handle_info(:purge, {cache(name: name), _last}) do
-    start_time = now()
-    new_caches = Overseer.retrieve(name)
+  def handle_info(:purge, {cache, false, _last}) do
+    started = now()
+
+    {duration, active} =
+      :timer.tc(fn ->
+        query =
+          Query.build(
+            where: {:not, {:==, :expiration, nil}},
+            output: true,
+            batch_size: 1
+          )
+
+        cache
+        |> Cachex.stream!(query, const(:local) ++ const(:notify_false))
+        |> Enum.empty?()
+      end)
+
+    last = %{
+      count: 0,
+      started: started,
+      duration: duration
+    }
+
+    handle_activation(active, {cache, false, last})
+  end
+
+  @doc false
+  # Executes an expiration cleanup against a cache table.
+  #
+  # This will drop to the ETS level and use a select to match documents which
+  # need to be removed; they are then deleted by ETS at very high speeds.
+  def handle_info(:purge, {cache, true, _last}) do
+    started = now()
 
     {duration, {:ok, count} = result} =
       :timer.tc(fn ->
-        Cachex.purge(new_caches, const(:local))
+        Cachex.purge(cache, const(:local))
       end)
 
     case count do
       0 -> nil
-      _ -> Informant.broadcast(new_caches, const(:purge_override_call), result)
+      _ -> Informant.broadcast(cache, const(:purge_override_call), result)
     end
 
     last = %{
       count: count,
-      duration: duration,
-      started: start_time
+      started: started,
+      duration: duration
     }
 
-    {:noreply, {schedule_check(new_caches), last}}
+    {:noreply, {schedule(cache), true, last}}
   end
+
+  @doc false
+  # Receives a provisioned cache instance.
+  #
+  # The provided cache is then stored in the state and used for cache calls going
+  # forwards, in order to skip the lookups inside the cache overseer for performance.
+  def handle_provision({:cache, cache}, {nil, active, last}),
+    do: {:ok, {schedule(cache), active, last}}
+
+  def handle_provision({:cache, cache}, {_cache, active, last}),
+    do: {:ok, {cache, active, last}}
 
   ###############
   # Private API #
   ###############
 
+  @doc false
+  # Handles lazy Janitor activation paradigms.
+  #
+  # If the first argument is true, it reflects that there are no records with
+  # an expiration defined so we re-schedule and skip.  In the case there are
+  # records with expiration defined, we continue to the main purge cycle.
+  defp handle_activation(true, {cache, _active, last}),
+    do: {:noreply, {schedule(cache), false, last}}
+
+  defp handle_activation(false, {cache, _active, last}),
+    do: handle_info(:purge, {cache, true, last})
+
   # Schedules a check to occur after the designated interval. Once scheduled,
   # returns the state - this is just sugar for pipelining with a state.
-  defp schedule_check(cache(expiration: expiration(interval: interval)) = cache) do
+  defp schedule(cache(expiration: expiration(interval: interval)) = cache) do
     :erlang.send_after(interval, self(), :purge)
     cache
   end

--- a/lib/cachex/services/steward.ex
+++ b/lib/cachex/services/steward.ex
@@ -38,7 +38,7 @@ defmodule Cachex.Services.Steward do
 
     services =
       cache
-      |> Services.services()
+      |> Services.list()
       |> Enum.filter(&filter_services/1)
 
     provisioned =

--- a/lib/cachex/services/steward.ex
+++ b/lib/cachex/services/steward.ex
@@ -11,6 +11,9 @@ defmodule Cachex.Services.Steward do
   attached to a cache, without the caller having to think about it.
   """
   import Cachex.Spec
+
+  # convenience alias
+  alias Cachex.Hook
   alias Cachex.Services
 
   # recognised
@@ -31,8 +34,7 @@ defmodule Cachex.Services.Steward do
   """
   @spec provide(Cachex.t(), {atom, any}) :: :ok
   def provide(cache() = cache, {key, _} = provision) when key in @provisions do
-    cache(hooks: hooks(pre: pre, post: post)) = cache
-    cache(warmers: warmers) = cache
+    cache(hooks: hooks, warmers: warmers) = cache
 
     services =
       cache
@@ -40,9 +42,9 @@ defmodule Cachex.Services.Steward do
       |> Enum.filter(&filter_services/1)
 
     provisioned =
-      services
-      |> Enum.concat(pre)
-      |> Enum.concat(post)
+      hooks
+      |> Hook.concat()
+      |> Enum.concat(services)
       |> Enum.concat(warmers)
       |> Enum.map(&map_names/1)
 

--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -84,7 +84,8 @@ defmodule Cachex.Spec do
   @type hooks ::
           record(:hooks,
             pre: [hook],
-            post: [hook]
+            post: [hook],
+            service: [hook]
           )
 
   # Record specification for a router instance
@@ -213,7 +214,8 @@ defmodule Cachex.Spec do
   """
   defrecord :hooks,
     pre: [],
-    post: []
+    post: [],
+    service: []
 
   @doc """
   Creates a router record from the provided values.

--- a/lib/cachex/spec/validator.ex
+++ b/lib/cachex/spec/validator.ex
@@ -87,7 +87,7 @@ defmodule Cachex.Spec.Validator do
     check5 = check4 and (enum?(action, &is_atom/1) or action == :all)
 
     check6 = check5 and enum?(module.provisions(), &is_atom/1)
-    check7 = check6 and module.type() in [:post, :pre]
+    check7 = check6 and module.type() in Cachex.Hook.types()
 
     check7
   end

--- a/lib/cachex/stats.ex
+++ b/lib/cachex/stats.ex
@@ -49,6 +49,10 @@ defmodule Cachex.Stats do
   ####################
 
   @doc false
+  def actions,
+    do: :all
+
+  @doc false
   # Initializes this hook with a new stats container.
   #
   # The `:creationDate` field is set inside the `:meta` field to contain the date

--- a/test/cachex/actions/stream_test.exs
+++ b/test/cachex/actions/stream_test.exs
@@ -89,6 +89,22 @@ defmodule Cachex.Actions.StreamTest do
     {cache, _nodes, _cluster} = TestUtils.create_cache_cluster(2)
 
     # we shouldn't be able to stream a cache on multiple nodes
-    assert(Cachex.stream(cache) == {:error, :non_distributed})
+    assert Cachex.stream(cache) == {:error, :non_distributed}
+  end
+
+  # We can force local: true to get a stream against the local node
+  @tag distributed: true
+  test "streaming is enabled in a cache cluster with local: true" do
+    # create a new cache cluster for cleaning
+    {cache, _nodes, _cluster} = TestUtils.create_cache_cluster(2)
+
+    # build a generic query to use later
+    query = Cachex.Query.build()
+
+    # create a cache stream with the local flag
+    stream = Cachex.stream(cache, query, local: true)
+
+    # we should be able to stream the local node
+    assert stream != {:error, :non_distributed}
   end
 end

--- a/test/cachex/hook_test.exs
+++ b/test/cachex/hook_test.exs
@@ -1,3 +1,75 @@
 defmodule Cachex.HookTest do
   use Cachex.Test.Case
+
+  setup_all do
+    ForwardHook.bind(
+      concat_hook_1: [type: :pre],
+      concat_hook_2: [type: :post],
+      concat_hook_3: [type: :service]
+    )
+
+    :ok
+  end
+
+  test "concatenating hooks in a cache" do
+    # create a set of 3 hooks to test with
+    hook1 = ForwardHook.create(:concat_hook_1)
+    hook2 = ForwardHook.create(:concat_hook_2)
+    hook3 = ForwardHook.create(:concat_hook_3)
+
+    # create a cache with our hooks
+    cache =
+      TestUtils.create_cache(
+        hooks: [
+          hook1,
+          hook2,
+          hook3
+        ]
+      )
+
+    # turn the cache into a cache state
+    cache1 = Services.Overseer.retrieve(cache)
+
+    # compare the order and all hooks listed
+    assert [
+             {:hook, :concat_hook_3, _, _},
+             {:hook, :concat_hook_2, _, _},
+             {:hook, :concat_hook_1, _, _}
+           ] = Cachex.Hook.concat(cache1)
+  end
+
+  test "locating hooks in a cache" do
+    # create a set of 3 hooks to test with
+    hook1 = ForwardHook.create(:concat_hook_1)
+    hook2 = ForwardHook.create(:concat_hook_2)
+    hook3 = ForwardHook.create(:concat_hook_3)
+
+    # create a cache with our hooks
+    cache =
+      TestUtils.create_cache(
+        hooks: [
+          hook1,
+          hook2,
+          hook3
+        ]
+      )
+
+    # turn the cache into a cache state
+    cache1 = Services.Overseer.retrieve(cache)
+
+    # locate each of the hooks (as they're different types)
+    locate1 = Cachex.Hook.locate(cache1, :concat_hook_1)
+    locate2 = Cachex.Hook.locate(cache1, :concat_hook_1, :pre)
+    locate3 = Cachex.Hook.locate(cache1, :concat_hook_2, :post)
+    locate4 = Cachex.Hook.locate(cache1, :concat_hook_3, :service)
+
+    # verify they all come back just as expected
+    assert {:hook, :concat_hook_1, _, _} = locate1
+    assert {:hook, :concat_hook_1, _, _} = locate2
+    assert {:hook, :concat_hook_2, _, _} = locate3
+    assert {:hook, :concat_hook_3, _, _} = locate4
+
+    # check that locating with the wrong type finds nothing
+    assert Cachex.Hook.locate(cache1, :concat_hook_1, :post) == nil
+  end
 end

--- a/test/cachex/spec_test.exs
+++ b/test/cachex/spec_test.exs
@@ -14,7 +14,7 @@ defmodule Cachex.SpecTest do
     do: assert(hook() == {:hook, nil, nil, nil})
 
   test "default hooks record values",
-    do: assert(hooks() == {:hooks, [], []})
+    do: assert(hooks() == {:hooks, [], [], []})
 
   test "generating constants via macros" do
     assert const(:local) == [local: true]


### PR DESCRIPTION
This fixes #367.

This PR will introduce the notion of `Cachex.Provision` to cache services, so they can also be provisioned just like hooks and warmers. As the Janitor uses `:cache`, this removes a table lookup on every call of the Janitor.

Also included is a change to `Cachex.Router` to allow actions which don't support distribution (i.e. `Cachex.stream/3`) to be called on the local node if `local: true`. This means we can go via `Cachex.stream/3` rather than `Cachex.Action.Stream.execute/3` when re-using it internally. 

Lastly the flow of the Janitor purge itself has changed. A Janitor is now flagged as "inactive" during initialization. An inactive Janitor will only do a quick sample to determine if there are any records in the cache with expiration set. If there aren't, it'll just short-circuit and repeat this process until there are.  To clarify "with expiration" does not mean "expired", just that the field is not `nil` in a single record.

Once a record with expiration is detected, it'll flag the Janitor as "active" and going forward the purge cycles will run as previously (including immediately). The previous sample will no longer run, so there's no overhead here compared to behaviour before this PR. 

Although this sounds more complicated, it skips out on the call to `Cachex.purge/2` which uses `Locksmith.transaction/3` under the hood and places a lock on the entire table. If you're not using expirations, this overhead will no longer affect you until you are, which is much better! 

