### PR TITLE
Add clause to Cachex.unwrap_unsafe/1 to allow unwrapping calls to Cac…

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -1441,4 +1441,7 @@ defmodule Cachex do
 
   defp unwrap_unsafe({_state, value}),
     do: value
+
+  defp unwrap_unsafe({_state, value, _opts}),
+    do: value
 end


### PR DESCRIPTION
…hex.fetch!/4 when options are provided

doctest from cachex.ex:
```
iex> Cachex.fetch(:my_cache, "missing_key_expires", fn(key) ->
...>   { :commit, String.reverse(key), expire: :timer.seconds(60) }
...> end)
{ :commit, "seripxe_yek_gnissim", [expire: 60000] }
```
The unsafe version Cachex.fetch!/4 will fail when providing options as in the example above due to a FunctionClauseError.
This PR adds the missing function clause. 