### PR TITLE
Add support for startup matching documentation

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -286,7 +286,10 @@ defmodule Cachex do
   #
   # Without this, Cachex is not compatible per Elixir's documentation.
   @spec start_link(atom | Keyword.t()) :: {atom, pid} | {:error, :invalid_name}
-  def start_link([name | options]) when is_atom(name) and is_list(options),
+  def start_link([name]) when is_atom(name),
+    do: start_link(name)
+
+  def start_link([name, options]) when is_atom(name) and is_list(options),
     do: start_link(name, options)
 
   def start_link(options) when is_list(options) do
@@ -300,7 +303,7 @@ defmodule Cachex do
   end
 
   def start_link(name) when is_atom(name),
-    do: start_link(name: name)
+    do: start_link(name, [])
 
   @doc """
   Creates a new Cachex cache service tree.

--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -286,6 +286,9 @@ defmodule Cachex do
   #
   # Without this, Cachex is not compatible per Elixir's documentation.
   @spec start_link(atom | Keyword.t()) :: {atom, pid} | {:error, :invalid_name}
+  def start_link([name | options]) when is_atom(name) and is_list(options),
+    do: start_link(name, options)
+
   def start_link(options) when is_list(options) do
     case Keyword.fetch(options, :name) do
       {:ok, name} ->

--- a/test/cachex_test.exs
+++ b/test/cachex_test.exs
@@ -228,9 +228,11 @@ defmodule CachexTest do
     # create two caches using `Cachex.start_link/1`
     {:ok, _pid} = Cachex.start_link(:child_spec1)
     {:ok, _pid} = Cachex.start_link(name: :child_spec2)
+    {:ok, _pid} = Cachex.start_link([:child_spec3])
 
     # verify that both are at least alive in some way
     {:ok, _cache1} = Cachex.inspect(:child_spec1, :cache)
     {:ok, _cache2} = Cachex.inspect(:child_spec2, :cache)
+    {:ok, _cache2} = Cachex.inspect(:child_spec3, :cache)
   end
 end

--- a/test/cachex_test.exs
+++ b/test/cachex_test.exs
@@ -225,14 +225,30 @@ defmodule CachexTest do
   # This test validates `Cachex.start_link/1` mtaintains compatibility
   # with `Supervisor.child_spec/2` and handles the name as an option.
   test "cache start with child_spec/1 compatibility" do
-    # create two caches using `Cachex.start_link/1`
+    # check the default ways of starting a cache
     {:ok, _pid} = Cachex.start_link(:child_spec1)
-    {:ok, _pid} = Cachex.start_link(name: :child_spec2)
+    {:ok, _pid} = Cachex.start_link(:child_spec2, transactions: true)
+
+    # check the format {Cachex, [:child_spec3]}
     {:ok, _pid} = Cachex.start_link([:child_spec3])
 
-    # verify that both are at least alive in some way
-    {:ok, _cache1} = Cachex.inspect(:child_spec1, :cache)
-    {:ok, _cache2} = Cachex.inspect(:child_spec2, :cache)
-    {:ok, _cache2} = Cachex.inspect(:child_spec3, :cache)
+    # check the format {Cachex, [:child_spec4, []]}
+    {:ok, _pid} = Cachex.start_link([:child_spec4, [transactions: true]])
+
+    # check the format {Cachex, [name: :child_spec5]}
+    {:ok, _pid} = Cachex.start_link(name: :child_spec5)
+
+    # check the format {Cachex, [name: :child_spec6, transactions: true]}
+    {:ok, _pid} = Cachex.start_link(name: :child_spec6, transactions: true)
+
+    # verify the caches that are created only from a name
+    {:ok, cache()} = Cachex.inspect(:child_spec1, :cache)
+    {:ok, cache()} = Cachex.inspect(:child_spec3, :cache)
+    {:ok, cache()} = Cachex.inspect(:child_spec5, :cache)
+
+    # double check those with options provided by double checking the value
+    {:ok, cache(transactions: true)} = Cachex.inspect(:child_spec2, :cache)
+    {:ok, cache(transactions: true)} = Cachex.inspect(:child_spec4, :cache)
+    {:ok, cache(transactions: true)} = Cachex.inspect(:child_spec6, :cache)
   end
 end


### PR DESCRIPTION
Fixes #383.

The current documentation is incorrect, but rather than just change the docs we can make it correct! This just adds some grace handling to some `child_spec` formats. 

It matches how you'd call it interactively, so I think it's quite beginner friendly to support these new formats. I kinda thought they were already there anyway... 