### PR TITLE
Fix monitor exclusion not being applied for newly detected nodes

### DIFF
--- a/lib/cachex/router/ring/monitor.ex
+++ b/lib/cachex/router/ring/monitor.ex
@@ -27,7 +27,7 @@ defmodule Cachex.Router.Ring.Monitor do
         type = Keyword.get(options, :monitor_type)
 
         includes = Keyword.get(options, :monitor_includes, [])
-        excludes = Keyword.get(options, :monitor_includes, [])
+        excludes = Keyword.get(options, :monitor_excludes, [])
 
         :ok = :net_kernel.monitor_nodes(true, node_type: type)
 

--- a/test/cachex/router/ring_test.exs
+++ b/test/cachex/router/ring_test.exs
@@ -124,7 +124,7 @@ defmodule Cachex.Router.RingTest do
   @tag distributed: true
   test "routing keys via a ring router with excluded nodes" do
     # create a test cache cluster for nodes
-    {cache, _nodes, _cluster} =
+    {cache, _nodes, cluster} =
       TestUtils.create_cache_cluster(3,
         router:
           router(
@@ -142,6 +142,13 @@ defmodule Cachex.Router.RingTest do
     cache = Services.Overseer.retrieve(cache)
 
     # verify that only the manage was attached to the ring
+    assert Cachex.Router.nodes(cache) == {:ok, [node()]}
+
+    {:ok, [_member1]} = LocalCluster.start(cluster, 1)
+
+    :timer.sleep(250)
+
+    # make sure that the exclusion applies on newly detected nodes
     assert Cachex.Router.nodes(cache) == {:ok, [node()]}
   end
 


### PR DESCRIPTION
Closes #388
## Summary
Fixes a small copy-paste typo making the `monitor_excludes` option not being used at all and the `monitor_includes` option being wrongly used in the `Ring` router to exclude newly detected nodes instead.

## Details
I was having the same issue of what #388 is describing and noticed that it was caused by remote accessing nodes. When a remote shell connects to an app's node, it doesn't get excluded by the default monitor exclusions defined in:
https://github.com/whitfin/cachex/blob/e1278ace99de35fba4e79695421eca1fd8502f8d/lib/cachex/router/ring.ex#L98-L102

You can see that the `rem-` values are showing up in [this comment](https://github.com/whitfin/cachex/issues/388#issuecomment-2477475452) when calling `Cachex.Router.connected()`
```elixir
iex(core@10.244.1.158)3> Cachex.Router.connected()
[:"core@10.244.1.158", :"rem-fe69-core@10.244.1.158", :"core@10.244.2.34"]

iex(core@10.244.2.34)15> Cachex.Router.connected()
[:"core@10.244.2.34", :"rem-92be-core@10.244.2.34", :"core@10.244.1.158"]
```
