### PR TITLE
Update Cachex.fetch documentation

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -587,9 +587,6 @@ defmodule Cachex do
 
   If a fallback function has an arity of 1, the requested entry key
   will be passed through to allow for contextual computation. If a
-  function has an arity of 2, the `:provide` option from the global
-  `:fallback` cache option will be provided as the second argument.
-  This is to allow easy state sharing, such as remote clients. If a
   function has an arity of 0, it will be executed without arguments.
 
   ## Examples


### PR DESCRIPTION
No longer supports fallback functions of arity 2 as of commit 172f303cf9f603dc5b57306d0763d7688b1883b1.