### PR TITLE
Update redundant spec

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -614,7 +614,7 @@ defmodule Cachex do
 
   """
   @spec fetch(Cachex.t(), any, function(), Keyword.t()) ::
-          {status | :commit | :ignore, any} | {:commit, any}
+          {status | :commit | :ignore, any}
   def fetch(cache, key, fallback, options \\ [])
       when is_function(fallback) and is_list(options),
       do: Router.route(cache, {:fetch, [key, fallback, options]})


### PR DESCRIPTION
After the discussion in #395, the spec for `Cachex.fetch/4` was updated in 0e3b9823649b6ff252d30249416e2fe28f9eddda, however the spec now contains the pattern `{:commit, any}` twice.
This PR removes the redundant spec pattern, as `{:commit, any}` is already a part of `{status | :commit | :ignore, any}`.