### PR TITLE
fix(Limit.Accessed): allow matching against missing cache items

### DIFF
--- a/lib/cachex/limit/accessed.ex
+++ b/lib/cachex/limit/accessed.ex
@@ -53,7 +53,7 @@ defmodule Cachex.Limit.Accessed do
   # This will update the modification time of a key if tracked in a successful cache
   # action. In combination with LRW caching, this provides a simple LRU policy.
   def handle_notify({_action, [key | _]}, _result, cache) do
-    {:ok, true} = Cachex.touch(cache, key)
+    {:ok, _} = Cachex.touch(cache, key)
     {:ok, cache}
   end
 


### PR DESCRIPTION
- currently the code hard matches against `Cachex.touch` returning true as its value, but if something is not in a cache already touch will return false
  - this ends up crashing the Accessed module server
- making the :ok match more generic  will prevent the gen_server from crashing

Fixes #401 