### PR TITLE
Fix cache warmer for long running tasks

### DIFF
--- a/lib/cachex/actions/warm.ex
+++ b/lib/cachex/actions/warm.ex
@@ -31,7 +31,7 @@ defmodule Cachex.Actions.Warm do
       warmers
       |> Enum.filter(&filter_mod(&1, only))
       |> Enum.map(&spawn_call(&1, wait))
-      |> Task.yield_many()
+      |> Task.yield_many(:infinity)
       |> Enum.map(&extract_name/1)
 
     {:ok, warmed}


### PR DESCRIPTION
As discussed in [the issue](#400), this PR fixes #400 for cases where the cache warmer fails for long running tasks.
