### PR TITLE
Align spec of `Cachex.Router.children/2` with values returned in code

### DIFF
--- a/lib/cachex/router.ex
+++ b/lib/cachex/router.ex
@@ -43,7 +43,7 @@ defmodule Cachex.Router do
   Create a child specification to back a routing state.
   """
   @callback children(cache :: Cachex.t(), options :: Keyword.t()) ::
-              Supervisor.child_spec()
+              [Supervisor.child_spec()]
 
   ##################
   # Implementation #

--- a/lib/cachex/router/ring.ex
+++ b/lib/cachex/router/ring.ex
@@ -87,7 +87,7 @@ defmodule Cachex.Router.Ring do
   Create a child specification to back a ring routing state.
   """
   @spec children(cache :: Cachex.t(), options :: Keyword.t()) ::
-          Supervisor.child_spec()
+          [Supervisor.child_spec()]
   def children(cache(name: name), options) do
     name = name(name, :router)
 


### PR DESCRIPTION
I was having some fun with dialyzer and found a spec that could easily be fixed to be aligned with the actual data returned by the function. :)