### PR TITLE
Update tests and utilities around $callers usage

### DIFF
--- a/lib/cachex/actions/warm.ex
+++ b/lib/cachex/actions/warm.ex
@@ -54,14 +54,12 @@ defmodule Cachex.Actions.Warm do
   end
 
   # Invokes a warmer with blocking enabled.
-  defp call_warmer(warmer(name: name), true) do
-    GenServer.call(name, {:cachex_warmer, get_callers()}, :infinity)
-  end
+  defp call_warmer(warmer(name: name), true),
+    do: GenServer.call(name, {:cachex_warmer, callers()}, :infinity)
 
   # Invokes a warmer with blocking disabled.
-  defp call_warmer(warmer(name: name), _) do
-    send(name, {:cachex_warmer, get_callers()})
-  end
+  defp call_warmer(warmer(name: name), _),
+    do: send(name, {:cachex_warmer, callers()})
 
   # Converts a task result to a name reference.
   defp extract_name({_, {:ok, name}}),

--- a/lib/cachex/hook.ex
+++ b/lib/cachex/hook.ex
@@ -140,7 +140,7 @@ defmodule Cachex.Hook do
 
       @doc false
       def handle_info({:cachex_notify, {event, result, callers}}, state) do
-        put_callers(callers)
+        Process.put(:"$callers", callers)
 
         case timeout() do
           nil ->

--- a/lib/cachex/services/courier.ex
+++ b/lib/cachex/services/courier.ex
@@ -39,13 +39,8 @@ defmodule Cachex.Services.Courier do
   call which will wait until a result can be loaded.
   """
   @spec dispatch(Cachex.t(), any, (-> any)) :: any
-  def dispatch(cache() = cache, key, task) when is_function(task, 0) do
-    service_call(
-      cache,
-      :courier,
-      {:dispatch, key, task, local_stack(), callers()}
-    )
-  end
+  def dispatch(cache() = cache, key, task) when is_function(task, 0),
+    do: service_call(cache, :courier, {:dispatch, key, task, local_stack(), callers()})
 
   ####################
   # Server Callbacks #

--- a/lib/cachex/services/informant.ex
+++ b/lib/cachex/services/informant.ex
@@ -67,7 +67,7 @@ defmodule Cachex.Services.Informant do
         # skip notifying service hooks
         if module.type() != :service do
           # define the base payload, regardless of type
-          payload = {:cachex_notify, {action, result, get_callers()}}
+          payload = {:cachex_notify, {action, result, [self() | callers()]}}
 
           # handle async vs. sync
           case module.async?() do

--- a/lib/cachex/services/locksmith/queue.ex
+++ b/lib/cachex/services/locksmith/queue.ex
@@ -39,7 +39,7 @@ defmodule Cachex.Services.Locksmith.Queue do
   @spec transaction(Cachex.t(), [any], (-> any)) :: any
   def transaction(cache() = cache, keys, func)
       when is_list(keys) and is_function(func, 0) do
-    service_call(cache, :locksmith, {:transaction, keys, func, get_callers()})
+    service_call(cache, :locksmith, {:transaction, keys, func, callers()})
   end
 
   ####################
@@ -73,8 +73,9 @@ defmodule Cachex.Services.Locksmith.Queue do
   # locks after execution. The key here is that the locks set on a key will stop
   # other processes from writing them, and force them to queue their writes
   # inside this queue process instead.
-  def handle_call({:transaction, keys, func, callers}, _ctx, cache) do
-    put_callers(callers)
+  def handle_call({:transaction, keys, func, callers}, {caller, _tag}, cache) do
+    Process.put(:"$callers", [caller | callers])
+
     true = lock(cache, keys)
     val = safe_exec(func)
     true = unlock(cache, keys)

--- a/lib/cachex/spec.ex
+++ b/lib/cachex/spec.ex
@@ -422,6 +422,12 @@ defmodule Cachex.Spec do
   #############
 
   @doc false
+  # Retrieves the $callers for the current process.
+  @spec callers() :: [pid()]
+  defmacro callers(),
+    do: quote(do: Process.get(:"$callers", []))
+
+  @doc false
   # Determines if a value is a negative integer.
   @spec is_negative_integer(integer) :: boolean
   defmacro is_negative_integer(integer),
@@ -470,22 +476,4 @@ defmodule Cachex.Spec do
   @spec wrap(any, atom) :: {atom, any}
   defmacro wrap(value, tag) when is_atom(tag),
     do: quote(do: {unquote(tag), unquote(value)})
-
-  # extracts list of `$callers` from the process dicionary
-  # and adds the current process to the list
-  # the intended use is to save it in a variable
-  # and use it inside spawned code
-  # e.g.
-  #
-  #     callers = get_callers()
-  #     spawn(fn -> put_callers() ... end)
-  #
-  # `$callers` allows mocking libraries like `Mox`
-  # to set mocks in the test process and use them
-  # in other processes that have the test process in `$callers`
-  @doc false
-  def get_callers(), do: [self() | Process.get(:"$callers") || []]
-
-  @doc false
-  def put_callers(callers), do: Process.put(:"$callers", callers)
 end

--- a/test/cachex/hook_test.exs
+++ b/test/cachex/hook_test.exs
@@ -81,7 +81,7 @@ defmodule Cachex.HookTest do
     cache = TestUtils.create_cache(hooks: [ExecuteHook.create()])
 
     # find the hook (with the populated runtime process identifier)
-    cache(hooks: hooks(post: [hook])) = Cachex.inspect!(cache, :cache)
+    cache(hooks: hooks(post: [hook])) = Services.Overseer.get(cache)
 
     # notify and fetch callers in order to send them back to this parent process
     Services.Informant.notify([hook], {:exec, fn -> Process.get(:"$callers") end}, nil)

--- a/test/cachex/test/hook/execute.ex
+++ b/test/cachex/test/hook/execute.ex
@@ -58,18 +58,14 @@ defmodule Cachex.Test.Hook.Execute do
           @doc """
           Executes a received function and forwards to the state process.
           """
-          def handle_notify({_tag, fun}, _results, proc) do
-            handle_info(fun.(), proc)
-            {:ok, proc}
-          end
+          def handle_notify({_tag, fun}, _results, proc) when is_function(fun, 0),
+            do: handle_info(fun.(), proc) && {:ok, proc}
 
           @doc """
           Forwards received messages to the state process.
           """
-          def handle_info(msg, proc) do
-            send(proc, msg)
-            {:noreply, proc}
-          end
+          def handle_info(msg, proc),
+            do: send(proc, msg) && {:noreply, proc}
         end
       end
     end


### PR DESCRIPTION
This PR will just normalize some tests around $callers to use the common utilities.

- Refactored calls to avoid duplicated passing (caller exists in `handle_call/3`)
- Added `$callers` support to locksmith execution
- Fixed re-schedule in warming due to missing `$callers`
- Fixed the issue with Elixir 1.7 (where `$callers` was not automated in `Task`)

