### PR TITLE
Update migration guide to include information about changed return value for Cachex.fetch/4

### DIFF
--- a/docs/migrations/migrating-to-v4.md
+++ b/docs/migrations/migrating-to-v4.md
@@ -69,6 +69,25 @@ This is covered in much more detail in the corresponding documentation of [Cache
 
 Last but not least, the `:transactional` flag has been renamed to `:transactions`. Ironically this used to be the name in the Cachex v2 days, but it turned out that it was a mistake to change it in Cachex v3!
 
+## Return Value Change
+
+The return value for `Cachex.fetch/4` has changed. When `fetch/4` is given a fallback function that returns a three-element tuple 
+(like `{ :commit, String.reverse(key), expire: :timer.seconds(60) }`), it returns a two-element tuple isntead of a three-element tuple.
+
+Typespec for `fetch/4` prior to 4.X:
+
+```elixir
+@spec fetch(cache(), any(), function() | nil, Keyword.t()) ::
+  {status() | :commit | :ignore, any()} | {:commit, any(), any()}
+```
+
+Typespec for `fetch/4` in 4.X:
+
+```elixir
+@spec fetch(Cachex.t(), any, function(), Keyword.t()) ::
+  {status | :commit | :ignore, any}
+```
+
 ## Warming Changes
 
 There are some minor changes to cache warmers in Cachex v4, which require only a couple of minutes to update.


### PR DESCRIPTION
The update to 4.X includes a breaking change to the return values for `Cachex.fetch/4`. Users who expected a three-element tuple to be returned with `:commit` will find the signature has changed.

Dialyzer caught this for my team and we were able to update our pattern matching. It might be useful to have this information in the migration guide for others.