### PR TITLE
Set default frequency to 1000ms for Cachex.Limit.Scheduled

### DIFF
--- a/lib/cachex/limit/scheduled.ex
+++ b/lib/cachex/limit/scheduled.ex
@@ -31,6 +31,8 @@ defmodule Cachex.Limit.Scheduled do
   # Hook Configuration #
   ######################
 
+  @default_frequency 1000
+
   @doc """
   Returns the provisions this policy requires.
   """
@@ -71,7 +73,7 @@ defmodule Cachex.Limit.Scheduled do
   # Schedules a check to occur after the designated interval.
   defp schedule(options) do
     options
-    |> Keyword.get(:frequency, :timer.seconds(3))
+    |> Keyword.get(:frequency, @default_frequency)
     |> :erlang.send_after(self(), :policy_check)
 
     :ok


### PR DESCRIPTION
When upgrading from Cachex 3.6 to 4.1 we noticed the behaviour of the pruning had changed compared to our own loose implementation of LRU on top of Cachex 3.6.
After some investigation we found that the default value for the pruning was not as defined in the documentation. This PR sets the default back to 1000ms (1 Second).
Once we updated the frequency via the Scheduled Hook options the behaviour returned to what we expected.

If the preference is to keep the default frequency at 3 seconds, then feel free to bin this PR. But it is worth noting the documentation and the migration guide would need to be updated to reflect the behaviour.