### PR TITLE
Update docs to remove references from V3

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -188,7 +188,7 @@ defmodule Cachex do
       The `:hooks` option allow the user to attach a list of notification hooks to
       enable listening on cache actions (either before or after they happen). These
       hooks should be valid `:hook` records provided by `Cachex.Spec`. Example hook
-      implementations can be found in `Cachex.Stats` and `Cachex.Policy.LRW`.
+      implementations can be found in `Cachex.Stats` and `Cachex.Limited.Scheduled`.
 
           iex> import Cachex.Spec
           ...>
@@ -795,8 +795,10 @@ defmodule Cachex do
 
       iex> Cachex.inspect(:my_cache, :cache)
       {:ok,
-        {:cache, :my_cache, %{}, {:expiration, nil, 3000, true}, {:fallback, nil, nil},
-          {:hooks, [], []}, {:limit, nil, Cachex.Policy.LRW, 0.1, []}, false, []}}
+        {:cache, :my_cache, %{}, false, {:expiration, nil, 3000, true}, 
+          {:hooks, [], [{:hook, Cachex.Stats, nil, #PID<0.986.0>}]}, 
+            [{:hook, Cachex.Limit.Scheduled, {500, [], []}, #PID<0.985.0>}], nil, false,
+          {:router, [], Cachex.Router.Local, nil}, false, []}}
 
       iex> Cachex.inspect(:my_cache, { :entry, "my_key" } )
       { :ok, { :entry, "my_key", 1475476615662, 1, "my_value" } }

--- a/lib/cachex/limit/scheduled.ex
+++ b/lib/cachex/limit/scheduled.ex
@@ -4,7 +4,7 @@ defmodule Cachex.Limit.Scheduled do
 
   This module implements a scheduled LRW eviction policy for Cachex, using a basic
   timer to trigger bound enforcement in a repeatable way. This has the same bound
-  accuracy as `Cachex.Policy.LRW.Evented`, but has potential for some delay. The
+  accuracy as `Cachex.Limit.Evented`, but has potential for some delay. The
   main advantage of this implementation is a far lower memory cost due to not
   using hook messages.
 


### PR DESCRIPTION
While upgrading from V3 to V4, I've noticed some references to modules in V4 docs that no longer exist.