### PR TITLE
Update typespecs for `Cachex.put/4` and `Cachex.put_many/3`

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -956,7 +956,7 @@ defmodule Cachex do
       { :ok, 5000 }
 
   """
-  @spec put(Cachex.t(), any, any, Keyword.t()) :: {status, boolean}
+  @spec put(Cachex.t(), any, any, Keyword.t()) :: {status, any}
   def put(cache, key, value, options \\ []) when is_list(options),
     do: Router.route(cache, {:put, [key, value, options]})
 
@@ -985,7 +985,7 @@ defmodule Cachex do
       { :ok, 5000 }
 
   """
-  @spec put_many(Cachex.t(), [{any, any}], Keyword.t()) :: {status, boolean}
+  @spec put_many(Cachex.t(), [{any, any}], Keyword.t()) :: {status, any}
   def put_many(cache, pairs, options \\ [])
       when is_list(pairs) and is_list(options),
       do: Router.route(cache, {:put_many, [pairs, options]})


### PR DESCRIPTION
These functions both define a return type of `{status, boolean}`:

```
  @spec put(Cachex.t(), any, any, Keyword.t()) :: {status, boolean}
  def put(cache, key, value, options \\ []) when is_list(options),

  # ...

  @spec put_many(Cachex.t(), [{any, any}], Keyword.t()) :: {status, boolean}
  def put_many(cache, pairs, options \\ [])
```

However, both functions may return a non-boolean value as the second element in the tuple, e.g. when an invalid cache name is given:

```
 iex> Cachex.put(:hello, :world, :ok)
{:error, :no_cache}
```

```
 iex> Cachex.put_many(:hello, [{:world, :ok}])
{:error, :no_cache}
```

This pull requests loosens the return type for these functions to use `{status, any}`.