### PR TITLE
Update fetch docs to explain existing nil value scenario

### DIFF
--- a/lib/cachex.ex
+++ b/lib/cachex.ex
@@ -565,8 +565,9 @@ defmodule Cachex do
   Fetches an entry from a cache, generating a value on cache miss.
 
   If the entry requested is found in the cache, this function will
-  operate in the same way as `get/3`. If the entry is not contained
-  in the cache, the provided fallback function will be executed.
+  operate in the same way as `get/3`. If the key does not exist
+  in the cache, or if it does exist but the value is nil, then the
+  provided fallback function will be executed.
 
   A fallback function is a function used to lazily generate a value
   to place inside a cache on miss. Consider it a way to achieve the


### PR DESCRIPTION
Otherwise it's not documented anywhere that if the key exists but the value is nil, it won't return the cache value but will instead run the fallback function. 

I ran into this unexpectedly, and found an old issue where you suggested a PR for updates to the docs but it doesn't look like that ever happened. Of course, feel free to reword any way you'd like.