### PR TITLE
Rename record type to cache_record type to fix compilation on Erlang 29.0

### DIFF
--- a/lib/cachex/spec/validator.ex
+++ b/lib/cachex/spec/validator.ex
@@ -10,7 +10,7 @@ defmodule Cachex.Spec.Validator do
   import Cachex.Spec
 
   # internal spec to refer to each record type
-  @type record ::
+  @type cache_record ::
           Cachex.Spec.command()
           | Cachex.Spec.entry()
           | Cachex.Spec.expiration()
@@ -31,7 +31,7 @@ defmodule Cachex.Spec.Validator do
 
   This will delegate each record type to a customized validation function.
   """
-  @spec valid?(atom, record) :: boolean
+  @spec valid?(atom, cache_record) :: boolean
 
   # Validates a command specification record.
   #


### PR DESCRIPTION
Erlang 29 (release candidate 1) doesn't allow built-in types (like record) to be redefined.
This leads to the following compilation error:
```
==> cachex
Compiling 56 files (.ex)

== Compilation error in file lib/cachex/spec/validator.ex ==
** (Kernel.TypespecError) lib/cachex/spec/validator.ex:14: type record/0 is a built-in type and it cannot be redefined
    (elixir 1.19.5) lib/kernel/typespec.ex:992: Kernel.Typespec.compile_error/2
    (stdlib 8.0) lists.erl:2465: :lists.foldl/3
    (elixir 1.19.5) lib/kernel/typespec.ex:230: Kernel.Typespec.translate_typespecs_for_module/2
```
I renamed the type `record` to `cache_record` to fix this.